### PR TITLE
Allow setting CN and validity days on certificate generation

### DIFF
--- a/cmd/deptokens/main.go
+++ b/cmd/deptokens/main.go
@@ -13,21 +13,19 @@ import (
 	"github.com/micromdm/nanodep/tokenpki"
 )
 
-const defaultCN = "deptokens"
-
 // overridden by -ldflags -X
 var version = "unknown"
 
 func main() {
 	var (
-		flCert         = flag.String("cert", "cert.pem", "path to certificate")
-		flKey          = flag.String("key", "cert.key", "path to key")
-		flCN           = flag.String("cn", defaultCN, "common name to use when creating the certificate")
-		flValidityDays = flag.Int64("validity-days", 0, "validity of the certificate in days")
-		flPassword     = flag.String("password", "", "password to encrypt/decrypt private key with")
-		flTokens       = flag.String("token", "", "path to tokens")
-		flForce        = flag.Bool("f", false, "force overwriting the keypair")
-		flVersion      = flag.Bool("version", false, "print version")
+		flCert     = flag.String("cert", "cert.pem", "path to certificate")
+		flKey      = flag.String("key", "cert.key", "path to key")
+		flCN       = flag.String("cn", "deptokens", "common name to use when creating the certificate")
+		flDays     = flag.Int64("days", 1, "validity of the certificate in days")
+		flPassword = flag.String("password", "", "password to encrypt/decrypt private key with")
+		flTokens   = flag.String("token", "", "path to tokens")
+		flForce    = flag.Bool("f", false, "force overwriting the keypair")
+		flVersion  = flag.Bool("version", false, "print version")
 	)
 	flag.Parse()
 
@@ -38,14 +36,14 @@ func main() {
 
 	var err error
 	if *flTokens == "" {
-		if *flValidityDays <= 0 {
-			fmt.Println("ERROR: missing or invalid -validity-days flag")
+		if *flDays <= 0 {
+			fmt.Println("ERROR: invalid -days flag")
 			os.Exit(1)
 		}
 		if *flPassword == "" {
 			fmt.Println("WARNING: no password provided, private key will be saved in clear text")
 		}
-		err = generateKeyPair(*flCert, *flKey, *flPassword, *flForce, *flCN, *flValidityDays)
+		err = generateKeyPair(*flCert, *flKey, *flPassword, *flForce, *flCN, *flDays)
 		if err == nil {
 			fmt.Printf("wrote %s, %s\n", *flCert, *flKey)
 		}
@@ -104,7 +102,7 @@ func decodeEncryptedKeyPEM(pemBytes []byte, password string) (*rsa.PrivateKey, e
 }
 
 // generateKeyPair creates and saves a keypair checking whether they exist first.
-func generateKeyPair(certFile, keyFile, password string, force bool, cn string, validityDays int64) error {
+func generateKeyPair(certFile, keyFile, password string, force bool, cn string, days int64) error {
 	if !force {
 		_, err := os.Stat(certFile)
 		certExists := err == nil
@@ -114,7 +112,7 @@ func generateKeyPair(certFile, keyFile, password string, force bool, cn string, 
 			return errors.New("cert or key already exist, not overwriting")
 		}
 	}
-	key, cert, err := tokenpki.SelfSignedRSAKeypair(cn, validityDays)
+	key, cert, err := tokenpki.SelfSignedRSAKeypair(cn, days)
 	if err != nil {
 		return fmt.Errorf("generating keypair: %w", err)
 	}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -158,6 +158,19 @@ paths:
       description: Generate and store a new X.509 certificate and RSA private key (keypair) for exchanging the encrypted DEP OAuth1 tokens via the Apple ABM/ASM/BE portal. Each request generates a new (and overwrites the existing) keypair. The certificate is returned.
       security:
         - basicAuth: []
+      parameters:
+      - in: query
+        name: cn
+        required: false
+        schema:
+          type: string
+          example: "depserver"
+      - in: query
+        name: validity_days
+        required: true
+        schema:
+          type: integer
+          example: 365
       responses:
         '200':
           description: X.509 certificate of the keypair used to encrypted the OAuth1 tokens.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -167,7 +167,7 @@ paths:
           example: "depserver"
       - in: query
         name: validity_days
-        required: true
+        required: false
         schema:
           type: integer
           example: 365

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -551,7 +551,7 @@ Print version and exit.
 #### Keypair generation
 
 ```bash
-$ ./deptokens-darwin-amd64 -password supersecret -validity-days 365
+$ ./deptokens-darwin-amd64 -password supersecret -validity-days 1
 wrote cert.pem, cert.key
 ```
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -77,7 +77,7 @@ The `/v1/tokenpki/{name}` endpoints deal with the public key exchange using the 
 
 * Endpoint: `GET, PUT /v1/tokens/{name}`
 
-The `/v1/tokens/{name} ` endpoints deal with the raw DEP OAuth tokens in JSON form. I.e. after the PKI exchange you can query for the actual DEP OAuth tokens if you like. This also allows configuring the OAuth1 tokens for a DEP name if you already have the tokens in JSON format. I.e. if you used the `deptokens` tool or you're using the DEP simulator `depsim`.
+The `/v1/tokens/{name}` endpoints deal with the raw DEP OAuth tokens in JSON form. I.e. after the PKI exchange you can query for the actual DEP OAuth tokens if you like. This also allows configuring the OAuth1 tokens for a DEP name if you already have the tokens in JSON format. I.e. if you used the `deptokens` tool or you're using the DEP simulator `depsim`.
 
 #### Assigner
 
@@ -172,7 +172,7 @@ For the DEP "MDM server" in the environment variable $DEP_NAME (see above) this 
 ##### Example usage
 
 ```bash
-$ ./tools/cfg-get-cert.sh > $DEP_NAME.pem
+$ ./tools/cfg-get-cert.sh depserver 365 > $DEP_NAME.pem
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100  1001  100  1001    0     0   4509      0 --:--:-- --:--:-- --:--:--  4509
@@ -520,6 +520,18 @@ The file path to read or save the RSA private key that corresponds to the public
 
 A password to encrypt or decrypt RSA private key on disk with. Note this is password is just to protect the private key itself and does not play a role in the token PKI exchange with Apple.
 
+#### -cn
+
+* common name to set in the certificate
+
+A Common Name string to set in the certificate (default is "depserver").
+
+#### -validity-days
+
+* validity of the generated certificate in days
+
+The generated certificate will expire after the provided days.
+
 #### -token string
 
 * path to tokens
@@ -539,7 +551,7 @@ Print version and exit.
 #### Keypair generation
 
 ```bash
-$ ./deptokens-darwin-amd64 -password supersecret
+$ ./deptokens-darwin-amd64 -password supersecret -validity-days 365
 wrote cert.pem, cert.key
 ```
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -169,6 +169,10 @@ The [Quickstart Guide](quickstart.md) also documents some usage of these scripts
 
 For the DEP "MDM server" in the environment variable $DEP_NAME (see above) this script generates and retrieves the public key certificate for use when downloading the DEP authentication tokens from the ABM/ASM/BE portal. The `curl` call will dump the PEM-encoded certificate to stdout so you'll likely want to redirect it somewhere useful so it can be uploaded to the portal.
 
+This script has two optional arguments:
+- The first argument specifies the Common Name to set in the certificate (default "depserver").
+- The second argument specifies the validity of the certificate in days (default 1 day).
+
 ##### Example usage
 
 ```bash
@@ -526,7 +530,7 @@ A password to encrypt or decrypt RSA private key on disk with. Note this is pass
 
 A Common Name string to set in the certificate (default is "depserver").
 
-#### -validity-days
+#### -days
 
 * validity of the generated certificate in days
 
@@ -551,7 +555,7 @@ Print version and exit.
 #### Keypair generation
 
 ```bash
-$ ./deptokens-darwin-amd64 -password supersecret -validity-days 1
+$ ./deptokens-darwin-amd64 -password supersecret
 wrote cert.pem, cert.key
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -43,11 +43,10 @@ Note here the "DEP name" of `mdmserver1` is arbitrary and can be anything you li
 The ABM/ASM/BE portal uses a public key to encrypt the OAuth1 tokens. To generate a new keypair and retrieve the public key (in an X.509 Certificate):
 
 ```bash
-$ ./tools/cfg-get-cert.sh depserver 365 > $DEP_NAME.pem
+$ ./tools/cfg-get-cert.sh > $DEP_NAME.pem
 ```
 
 Note this should create a new file called "mdmserver1.pem" (or whatever you set `$DEP_NAME` to, above).
-The first argument of the tool is the Common Name and the second is the validity of the certificate in days.
 
 ### Upload the public key to ABM/ASM/BE
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -43,10 +43,11 @@ Note here the "DEP name" of `mdmserver1` is arbitrary and can be anything you li
 The ABM/ASM/BE portal uses a public key to encrypt the OAuth1 tokens. To generate a new keypair and retrieve the public key (in an X.509 Certificate):
 
 ```bash
-$ ./tools/cfg-get-cert.sh > $DEP_NAME.pem
+$ ./tools/cfg-get-cert.sh depserver 365 > $DEP_NAME.pem
 ```
 
 Note this should create a new file called "mdmserver1.pem" (or whatever you set `$DEP_NAME` to, above).
+The first argument of the tool is the Common Name and the second is the validity of the certificate in days.
 
 ### Upload the public key to ABM/ASM/BE
 

--- a/tokenpki/cert.go
+++ b/tokenpki/cert.go
@@ -14,7 +14,7 @@ import (
 // SelfSignedRSAKeypair generates a 2048-bit RSA private key and self-signs an
 // X.509 certificate using it. You can set the Common Name in cn and the
 // validity duration with days.
-func SelfSignedRSAKeypair(cn string, days int) (*rsa.PrivateKey, *x509.Certificate, error) {
+func SelfSignedRSAKeypair(cn string, days int64) (*rsa.PrivateKey, *x509.Certificate, error) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, nil, err

--- a/tools/cfg-get-cert.sh
+++ b/tools/cfg-get-cert.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 
-CN="${1:-depserver}"
-VALIDITY_DAYS="${2:-1}"
-URL="${BASE_URL}/v1/tokenpki/${DEP_NAME}?cn=$CN&validity_days=$VALIDITY_DAYS"
+URL="${BASE_URL}/v1/tokenpki/${DEP_NAME}?cn=$1&validity_days=$2"
 
 curl \
 	$CURL_OPTS \

--- a/tools/cfg-get-cert.sh
+++ b/tools/cfg-get-cert.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-URL="${BASE_URL}/v1/tokenpki/${DEP_NAME}?cn=$1&validity_days=$2"
+CN="${1:-depserver}"
+VALIDITY_DAYS="${2:-1}"
+URL="${BASE_URL}/v1/tokenpki/${DEP_NAME}?cn=$CN&validity_days=$VALIDITY_DAYS"
 
 curl \
 	$CURL_OPTS \

--- a/tools/cfg-get-cert.sh
+++ b/tools/cfg-get-cert.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-URL="${BASE_URL}/v1/tokenpki/${DEP_NAME}"
+URL="${BASE_URL}/v1/tokenpki/${DEP_NAME}?cn=$1&validity_days=$2"
 
 curl \
 	$CURL_OPTS \


### PR DESCRIPTION
This allow setting a custom CN and validity days on `GET /v1/tokenpki/{name}`. Such API was always using default values CN=depserver and days=1.

See https://github.com/micromdm/nanodep/pull/5#discussion_r927016919.