### PR TITLE
Add cursor modification time to `storage.AllStorage`'s `RetrieveCursor` interface method

### DIFF
--- a/storage/file/file.go
+++ b/storage/file/file.go
@@ -139,16 +139,24 @@ func (s *FileStorage) StoreAssignerProfile(_ context.Context, name string, profi
 	return os.WriteFile(s.profileFilename(name), []byte(profileUUID+"\n"), defaultFileMode)
 }
 
-// RetrieveCursor reads the reads the DEP fetch and sync cursor from disk
-// for name DEP name. We return an empty cursor if the cursor does not exist
-// on disk.
-func (s *FileStorage) RetrieveCursor(_ context.Context, name string) (string, error) {
+// RetrieveCursor reads the reads the DEP fetch and sync cursor for name DEP name.
+//
+// Returns an empty cursor with empty modTime if the cursor does not exist.
+func (s *FileStorage) RetrieveCursor(_ context.Context, name string) (string, time.Time, error) {
 	cursorBytes, err := os.ReadFile(s.cursorFilename(name))
 	if err != nil && errors.Is(err, os.ErrNotExist) {
 		// an 'empty' cursor is valid
-		return "", nil
+		return "", time.Time{}, nil
 	}
-	return strings.TrimSpace(string(cursorBytes)), err
+	modTime := time.Time{}
+	if err == nil {
+		var stat fs.FileInfo
+		stat, err = os.Stat(s.cursorFilename(name))
+		if err == nil {
+			modTime = stat.ModTime()
+		}
+	}
+	return strings.TrimSpace(string(cursorBytes)), modTime, err
 }
 
 // StoreCursor saves the DEP fetch and sync cursor to disk for name DEP name.

--- a/storage/mysql/schema.sql
+++ b/storage/mysql/schema.sql
@@ -17,7 +17,8 @@ CREATE TABLE dep_names (
 
     -- Syncer
     -- From Apple docs: "The string can be up to 1000 characters".
-    syncer_cursor VARCHAR(1024) NULL,
+    syncer_cursor    VARCHAR(1024) NULL,
+    syncer_cursor_at TIMESTAMP NULL,
 
     -- Assigner
     assigner_profile_uuid    TEXT NULL,

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -15,7 +15,11 @@ import (
 // CursorStorage is where the device fetch and sync cursor can be stored and
 // retrieved for a given DEP name.
 type CursorStorage interface {
-	RetrieveCursor(ctx context.Context, name string) (string, error)
+	// RetrieveCursor reads the reads the DEP fetch and sync cursor for name DEP name.
+	// It returns the time when the cursor was stored.
+	//
+	// Returns an empty cursor with empty modTime if the cursor does not exist.
+	RetrieveCursor(ctx context.Context, name string) (cursor string, modTime time.Time, err error)
 	StoreCursor(ctx context.Context, name string, cursor string) error
 }
 
@@ -110,7 +114,7 @@ func (s *Syncer) Run(ctx context.Context) error {
 		false: "sync",
 	}
 	var resp *godep.DeviceResponse
-	cursor, err := s.store.RetrieveCursor(ctx, s.name)
+	cursor, _, err := s.store.RetrieveCursor(ctx, s.name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We believe this is needed by syncer+assigner for the following scenario:

If all device events have been fetched/synced (the cursor in storage is updated), and the operator/administrator updates the assigner profile UUID, then we would like to re-apply the profile to all devices.

With this change, projects that use `nanodep` can support the above scenario by comparing the `syncer_cursor_at` with `assigner_profile_uuid_at`, and remove/clear the cursor from storage if the latter is newer than the former.

This is mimicking `RetrieveAssignerProfile` which also returns the `modTime` for the assigner profile:
```go
RetrieveAssignerProfile(ctx context.Context, name string) (profileUUID string, modTime time.Time, err error)
```