### PR TITLE
Fix initial token loading

### DIFF
--- a/http/api/ckcheck.go
+++ b/http/api/ckcheck.go
@@ -35,7 +35,7 @@ func (t *CKCheck) StoreAuthTokens(ctx context.Context, name string, tokens *clie
 	if err != nil {
 		return fmt.Errorf("retrieving auth tokens: %w", err)
 	}
-	if prevTokens.ConsumerKey != tokens.ConsumerKey {
+	if prevTokens.ConsumerKey != tokens.ConsumerKey && prevTokens.ConsumerKey != "" {
 		return CKMismatch
 	}
 	return t.AuthTokensStorer.StoreAuthTokens(ctx, name, tokens)

--- a/storage/file/file.go
+++ b/storage/file/file.go
@@ -83,6 +83,9 @@ func (s *FileStorage) StoreAuthTokens(_ context.Context, name string, tokens *cl
 func decodeJSONfile(filename string, v interface{}) error {
 	f, err := os.Open(filename)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 	defer f.Close()


### PR DESCRIPTION
Currently token bootstrapping with the file backend is non-functional. This PR resolves that issue

When performing the token upload operation you'd get one of the two errors
```json
{
  "error": "retrieving auth tokens: open db/nanomdm-dev.tokens.json: no such file or directory"
}
```
or
```json
{
  "error": "mismatched consumer key"
}
```

This PR adds some error validation, and default value checking to resolve this issue