### PR TITLE
Handle assignment to moved devices

### DIFF
--- a/sync/assigner.go
+++ b/sync/assigner.go
@@ -130,12 +130,17 @@ func (a *Assigner) ProcessDeviceResponse(ctx context.Context, resp *godep.Device
 // shouldAssignDevice decides whether a device "event" should be passed
 // off to the assigner.
 func shouldAssignDevice(device godep.Device) bool {
-	// we currently only listen for an op_type of "added." the other
-	// op_types are ambiguous and it would be needless to assign the
-	// profile UUID every single time we get an update.
+	// op_type of "added" indicates a net new device was added to a dep name
 	if strings.ToLower(device.OpType) == "added" {
 		return true
 	}
+
+	// op_type of "modified" with profile status of "removed" indicates an existing
+	// device that was moved to a new dep name
+	if strings.ToLower(device.OpType) == "modified" && strings.ToLower(device.ProfileStatus) == "removed" {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
This came up in our internal testing when using the assigner, but unsure if we're right to make this change. This PR is mostly to gain consensus on what the behavior in ABM actually is when re-assigning devices from one server to another.

In our environment we aren't assigning newly purchased devices to our dev server. Instead we are moving devices in and out with the hope that the sync/assign would know what to do. The observation is that devices moved to our dev server were coming in with an `op_type: modified` and a `profilestatus: removed`

Curious if this is what others are seeing.