### PR TITLE
copy User-Agent from DEP request to auth/session request

### DIFF
--- a/client/transport.go
+++ b/client/transport.go
@@ -221,6 +221,10 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 			sessionURL.String(),
 			nil,
 		)
+		if userAgent := req.Header.Get("User-Agent"); userAgent != "" {
+			// copy the UA from the original request to the auth request
+			sessionReq.Header.Set("User-Agent", userAgent)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("transport: creating session request: %w", err)
 		}


### PR DESCRIPTION
Investigating #42 found that we were not setting the User-Agent on the session/authentication request to the DEP API to retrieve the session token. This did *not* solve the issue but may be a good practice. It was originally omitted because it wasn't necessary in the first place.