### PR TITLE
Add consumer key change force mode to tokenPKI handler

### DIFF
--- a/http/api/tokenpki.go
+++ b/http/api/tokenpki.go
@@ -146,6 +146,6 @@ func DecryptTokenPKIHandler(store TokenPKIRetriever, tokenStore AuthTokensStore,
 			jsonError(w, err)
 			return
 		}
-		storeTokens(r.Context(), logger, r.URL.Path, tokens, tokenStore, w, false)
+		storeTokens(r.Context(), logger, r.URL.Path, tokens, tokenStore, w, force)
 	}
 }


### PR DESCRIPTION
I have discovered that a "force" parameter is added to the DecryptTokenPKIHandler function. However, this is not passed to the storeTokens function.