### PR TITLE
godep: os beta enrollment

### DIFF
--- a/godep/beta.go
+++ b/godep/beta.go
@@ -5,26 +5,26 @@ import (
 	"net/http"
 )
 
-// OSToken corresponds to the Apple DEP API "???" structure.
-// See https://developer.apple.com/documentation/devicemanagement/???
-type OSToken struct {
+// SeedBuildToken corresponds to the Apple DEP API "SeedBuildToken" structure.
+// See https://developer.apple.com/documentation/devicemanagement/seedbuildtoken
+type SeedBuildToken struct {
 	Token string `json:"token"`
 	Title string `json:"title"`
 	OS    string `json:"os"`
 }
 
-// OSBetaEnrollmentTokens corresponds to the Apple DEP API "???" structure.
-// See https://developer.apple.com/documentation/devicemanagement/???
-type OSBetaEnrollmentTokens struct {
-	BetaEnrollmentTokens []OSToken `json:"betaEnrollmentTokens,omitempty"`
-	SeedBuildTokens      []OSToken `json:"seedBuildTokens,omitempty"`
+// GetSeedBuildTokenResponse corresponds to the Apple DEP API "GetSeedBuildTokenResponse" structure.
+// See https://developer.apple.com/documentation/devicemanagement/getseedbuildtokenresponse
+type GetSeedBuildTokenResponse struct {
+	BetaEnrollmentTokens []SeedBuildToken `json:"betaEnrollmentTokens,omitempty"`
+	SeedBuildTokens      []SeedBuildToken `json:"seedBuildTokens,omitempty"`
 }
 
-// OSBetaEnrollmentTokens uses the Apple "???" API endpoint to fetch the
+// OSBetaEnrollmentTokens uses the Apple "Get Beta Enrollment Tokens" API endpoint to fetch the
 // OS beta enrollment tokens. These are for later use during ADE
 // enrollment of devices to force enrollment into beta software enrollment.
-// See https://developer.apple.com/documentation/devicemanagement/???
-func (c *Client) OSBetaEnrollmentTokens(ctx context.Context, name string) (*OSBetaEnrollmentTokens, error) {
+// See https://developer.apple.com/documentation/devicemanagement/get_beta_enrollment_tokens
+func (c *Client) OSBetaEnrollmentTokens(ctx context.Context, name string) (*OSBetaEnrollmentTokensResponse, error) {
 	resp := new(OSBetaEnrollmentTokens)
 	return resp, c.do(ctx, name, http.MethodGet, "/os-beta-enrollment/tokens", nil, resp)
 }

--- a/godep/beta.go
+++ b/godep/beta.go
@@ -30,6 +30,6 @@ func (c *Client) OSBetaEnrollmentTokens(ctx context.Context, name string) (*GetS
 }
 
 // IsAppleSeedForITTurnedOff returns true if err indicates your organization doesn't allow beta access.
-func IsAppleSeedTurnedOff(err error) bool {
+func IsAppleSeedForITTurnedOff(err error) bool {
 	return httpErrorContains(err, http.StatusForbidden, "APPLE_SEED_FOR_IT_TURNED_OFF")
 }

--- a/godep/beta.go
+++ b/godep/beta.go
@@ -24,7 +24,7 @@ type GetSeedBuildTokenResponse struct {
 // OS beta enrollment tokens. These are for later use during ADE
 // enrollment of devices to force enrollment into beta software enrollment.
 // See https://developer.apple.com/documentation/devicemanagement/get_beta_enrollment_tokens
-func (c *Client) OSBetaEnrollmentTokens(ctx context.Context, name string) (*OSBetaEnrollmentTokensResponse, error) {
-	resp := new(OSBetaEnrollmentTokens)
+func (c *Client) OSBetaEnrollmentTokens(ctx context.Context, name string) (*GetSeedBuildTokenResponse, error) {
+	resp := new(GetSeedBuildTokenResponse)
 	return resp, c.do(ctx, name, http.MethodGet, "/os-beta-enrollment/tokens", nil, resp)
 }

--- a/godep/beta.go
+++ b/godep/beta.go
@@ -1,0 +1,30 @@
+package godep
+
+import (
+	"context"
+	"net/http"
+)
+
+// OSToken corresponds to the Apple DEP API "???" structure.
+// See https://developer.apple.com/documentation/devicemanagement/???
+type OSToken struct {
+	Token string `json:"token"`
+	Title string `json:"title"`
+	OS    string `json:"os"`
+}
+
+// OSBetaEnrollmentTokens corresponds to the Apple DEP API "???" structure.
+// See https://developer.apple.com/documentation/devicemanagement/???
+type OSBetaEnrollmentTokens struct {
+	BetaEnrollmentTokens []OSToken `json:"betaEnrollmentTokens,omitempty"`
+	SeedBuildTokens      []OSToken `json:"seedBuildTokens,omitempty"`
+}
+
+// OSBetaEnrollmentTokens uses the Apple "???" API endpoint to fetch the
+// OS beta enrollment tokens. These are for later use during ADE
+// enrollment of devices to force enrollment into beta software enrollment.
+// See https://developer.apple.com/documentation/devicemanagement/???
+func (c *Client) OSBetaEnrollmentTokens(ctx context.Context, name string) (*OSBetaEnrollmentTokens, error) {
+	resp := new(OSBetaEnrollmentTokens)
+	return resp, c.do(ctx, name, http.MethodGet, "/os-beta-enrollment/tokens", nil, resp)
+}

--- a/godep/beta.go
+++ b/godep/beta.go
@@ -28,3 +28,8 @@ func (c *Client) OSBetaEnrollmentTokens(ctx context.Context, name string) (*GetS
 	resp := new(GetSeedBuildTokenResponse)
 	return resp, c.do(ctx, name, http.MethodGet, "/os-beta-enrollment/tokens", nil, resp)
 }
+
+// IsAppleSeedForITTurnedOff returns true if err indicates your organization doesn't allow beta access.
+func IsAppleSeedTurnedOff(err error) bool {
+	return httpErrorContains(err, http.StatusForbidden, "APPLE_SEED_FOR_IT_TURNED_OFF")
+}


### PR DESCRIPTION
Support the new [OS beta enrollment endpoint](https://developer.apple.com/documentation/devicemanagement/get_beta_enrollment_tokens) for organizations enrolled in AppleSeed for IT  *within the godep library* (any endpoint, including this one, has already been supported when using the transparent proxy). Please see the [AppleSeed for IT](http://beta.apple.com) release notes and test plan for more information.