### PR TITLE
new inmem and filekv storage backends

### DIFF
--- a/cli/storage.go
+++ b/cli/storage.go
@@ -2,6 +2,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -13,16 +14,19 @@ import (
 )
 
 // Storage parses a storage name and dsn to determine which and return a storage backend.
-func Storage(storageName, dsn string) (storage.AllStorage, error) {
+func Storage(storageName, dsn, options string) (storage.AllStorage, error) {
 	var store storage.AllStorage
 	var err error
 	switch storageName {
-	case "file":
+	case "filekv":
 		if dsn == "" {
 			dsn = "dbkv"
 		}
 		store = diskv.New(dsn)
-	case "file.deprecated":
+	case "file":
+		if options != "enable_deprecated=1" {
+			return nil, errors.New("file backend is deprecated; specify storage options to force enable")
+		}
 		if dsn == "" {
 			dsn = "db"
 		}

--- a/cli/storage.go
+++ b/cli/storage.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/micromdm/nanodep/storage"
 	"github.com/micromdm/nanodep/storage/file"
+	"github.com/micromdm/nanodep/storage/inmem"
 	"github.com/micromdm/nanodep/storage/mysql"
 )
 
@@ -20,6 +21,8 @@ func Storage(storageName, dsn string) (storage.AllStorage, error) {
 			dsn = "db"
 		}
 		store, err = file.New(dsn)
+	case "inmem":
+		store = inmem.New()
 	case "mysql":
 		store, err = mysql.New(mysql.WithDSN(dsn))
 	default:

--- a/cli/storage.go
+++ b/cli/storage.go
@@ -6,6 +6,7 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/micromdm/nanodep/storage"
+	"github.com/micromdm/nanodep/storage/diskv"
 	"github.com/micromdm/nanodep/storage/file"
 	"github.com/micromdm/nanodep/storage/inmem"
 	"github.com/micromdm/nanodep/storage/mysql"
@@ -21,6 +22,11 @@ func Storage(storageName, dsn string) (storage.AllStorage, error) {
 			dsn = "db"
 		}
 		store, err = file.New(dsn)
+	case "diskv":
+		if dsn == "" {
+			dsn = "diskv"
+		}
+		store = diskv.New(dsn)
 	case "inmem":
 		store = inmem.New()
 	case "mysql":

--- a/cli/storage.go
+++ b/cli/storage.go
@@ -19,14 +19,14 @@ func Storage(storageName, dsn string) (storage.AllStorage, error) {
 	switch storageName {
 	case "file":
 		if dsn == "" {
+			dsn = "dbkv"
+		}
+		store = diskv.New(dsn)
+	case "file.deprecated":
+		if dsn == "" {
 			dsn = "db"
 		}
 		store, err = file.New(dsn)
-	case "diskv":
-		if dsn == "" {
-			dsn = "diskv"
-		}
-		store = diskv.New(dsn)
 	case "inmem":
 		store = inmem.New()
 	case "mysql":

--- a/client/client.go
+++ b/client/client.go
@@ -21,7 +21,7 @@ type Config struct {
 }
 
 type ConfigRetriever interface {
-	// RetrieveConfig reads the DEP name config of name.
+	// RetrieveConfig retrieves config of name (DEP name).
 	// If the DEP name or config does not exist then a nil config and
 	// nil error should be returned.
 	RetrieveConfig(ctx context.Context, name string) (*Config, error)

--- a/client/client.go
+++ b/client/client.go
@@ -21,10 +21,9 @@ type Config struct {
 }
 
 type ConfigRetriever interface {
-	// RetrieveConfig reads the JSON DEP config of a DEP name.
-	//
-	// Returns (nil, nil) if the DEP name does not exist, or if the config
-	// for the DEP name does not exist.
+	// RetrieveConfig reads the DEP name config of name.
+	// If the DEP name or config does not exist then a nil config and
+	// nil error should be returned.
 	RetrieveConfig(ctx context.Context, name string) (*Config, error)
 }
 

--- a/client/transport.go
+++ b/client/transport.go
@@ -41,7 +41,7 @@ func GetName(ctx context.Context) string {
 }
 
 type AuthTokensRetriever interface {
-	// RetrieveAuthTokens reads the OAuth tokens from storage for name (DEP name).
+	// RetrieveAuthTokens retrieves the OAuth tokens from storage for name (DEP name).
 	// If the name or tokens do not exist storage.ErrNotFound should be returned.
 	RetrieveAuthTokens(ctx context.Context, name string) (*OAuth1Tokens, error)
 }

--- a/client/transport.go
+++ b/client/transport.go
@@ -41,6 +41,8 @@ func GetName(ctx context.Context) string {
 }
 
 type AuthTokensRetriever interface {
+	// RetrieveAuthTokens reads the OAuth tokens from storage for name (DEP name).
+	// If the name or tokens do not exist storage.ErrNotFound should be returned.
 	RetrieveAuthTokens(ctx context.Context, name string) (*OAuth1Tokens, error)
 }
 

--- a/cmd/depserver/main.go
+++ b/cmd/depserver/main.go
@@ -38,8 +38,9 @@ func main() {
 		flListen  = flag.String("listen", ":9001", "HTTP listen address")
 		flAPIKey  = flag.String("api", "", "API key for API endpoints")
 		flVersion = flag.Bool("version", false, "print version")
-		flStorage = flag.String("storage", "file", "storage backend")
-		flDSN     = flag.String("storage-dsn", "", "storage data source name")
+		flStorage = flag.String("storage", "filekv", "storage backend")
+		flDSN     = flag.String("storage-dsn", "", "storage backend data source name")
+		flOptions = flag.String("storage-options", "", "storage backend options")
 	)
 	flag.Parse()
 
@@ -59,7 +60,7 @@ func main() {
 		stdlogfmt.WithDebugFlag(*flDebug),
 	)
 
-	storage, err := cli.Storage(*flStorage, *flDSN)
+	storage, err := cli.Storage(*flStorage, *flDSN, *flOptions)
 	if err != nil {
 		logger.Info("msg", "creating storage backend", "err", err)
 		os.Exit(1)

--- a/cmd/depsyncer/main.go
+++ b/cmd/depsyncer/main.go
@@ -31,8 +31,9 @@ func main() {
 		flDebug   = flag.Bool("debug", false, "log debug messages")
 		flADebug  = flag.Bool("debug-assigner", false, "additional debug logging of the device assigner")
 		flSDebug  = flag.Bool("debug-syncer", false, "additional debug logging of the device syncer")
-		flStorage = flag.String("storage", "file", "storage backend")
-		flDSN     = flag.String("storage-dsn", "", "storage data source name")
+		flStorage = flag.String("storage", "filekv", "storage backend")
+		flDSN     = flag.String("storage-dsn", "", "storage backend data source name")
+		flOptions = flag.String("storage-options", "", "storage backend options")
 		flWebhook = flag.String("webhook-url", "", "URL to send requests to")
 		flUA      = flag.String("user-agent", godep.UserAgent, "User-Agent string to use")
 	)
@@ -58,7 +59,7 @@ func main() {
 		stdlogfmt.WithDebugFlag(*flDebug),
 	)
 
-	storage, err := cli.Storage(*flStorage, *flDSN)
+	storage, err := cli.Storage(*flStorage, *flDSN, *flOptions)
 	if err != nil {
 		logger.Info("msg", "creating storage backend", "err", err)
 		os.Exit(1)

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -57,12 +57,12 @@ Configure the `file` storage backend. This backend manages DEP authentication an
 * `-storage file.deprecated`
 
 > [!WARNING]
-> The `file.deprecated` (formerly the default `file` backend) will be removed from a future NanoDEP release.
+> The `file.deprecated` (formerly the default `file` backend) will be removed in a future NanoDEP release.
 
 Configure the `file.deprecated` storage backend. This backend manages DEP authentication and configuration data within plain filesystem files and directories. It has zero dependencies and should run out of the box. The `-storage-dsn` flag specifies the filesystem directory for the database. If no `storage-dsn` is specified then `db` is used as a default.
 
 > [!NOTE]
-> This was previously the default `file` storage backend in NanoDEP v0.4 and below. 
+> This was previously the default `file` storage backend in NanoDEP v0.4 and below.
 
 *Example:* `-storage file.deprecated -storage-dsn /path/to/my/db`
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -49,6 +49,14 @@ Configure the `file` storage backend. This backend manages DEP authentication an
 
 *Example:* `-storage file -storage-dsn /path/to/my/db`
 
+##### in-memory storage backend
+
+* `-storage inmem`
+
+Configure the `inmem` in-memory storage backend. This backend manages DEP authentication and configuration data entirely in volatile memory. The DSN is ignored. **WARNING: all data is lost when the server or tool process has exited.**
+
+*Example:* `-storage inmem`
+
 ##### mysql storage backend
 
 * `-storage mysql`

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -41,6 +41,14 @@ Specifies the listen address (interface and port number) for the server to liste
 
 The `-storage` and `-storage-dsn` flags together configure the storage backend. `-storage` specifies the name of backend type while `-storage-dsn` specifies the backend data source name (e.g. the connection string). If no `-storage` backend is specified then `file` is used as a default.
 
+##### diskv storage backend
+
+* `-storage diskv`
+
+Configure the `diskv` storage backend. This backend manages DEP authentication and configuration data within plain filesystem files and directories. It has zero dependencies and should run out of the box. The `-storage-dsn` flag specifies the filesystem directory for the database. If no `storage-dsn` is specified then `diskv` is used as a default.
+
+*Example:* `-storage diskv -storage-dsn /path/to/my/db`
+
 ##### file storage backend
 
 * `-storage file`

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -45,7 +45,7 @@ The `-storage`, `-storage-dsn`, and `-storage-options` flags together configure 
 
 * `-storage filekv`
 
-Uses the `filekv` storage backend. This backend manages DEP authentication and configuration data within plain filesystem files and directories using a key-value storage system. It has zero dependencies, no options, and should run out of the box. The `-storage-dsn` flag specifies the filesystem directory for the database. If no `storage-dsn` is specified then `dbkv` is used as a default.
+Configure the `filekv` storage backend. This backend manages DEP authentication and configuration data within plain filesystem files and directories using a key-value storage system. It has zero dependencies, no options, and should run out of the box. The `-storage-dsn` flag specifies the filesystem directory for the database. If no `storage-dsn` is specified then `dbkv` is used as a default.
 
 *Example:* `-storage filekv -storage-dsn /path/to/my/db`
 
@@ -56,7 +56,7 @@ Uses the `filekv` storage backend. This backend manages DEP authentication and c
 > [!WARNING]
 > The `file` storage backend is deprecated in NanoDEP v0.4 and will be removed in a future release.
 
-Uses the `file` storage backend. This backend manages DEP authentication and configuration data within plain filesystem files and directories. It has zero dependencies and and should run out of the box. The `-storage-dsn` flag specifies the filesystem directory for the database. If no `storage-dsn` is specified then `db` is used as a default.
+Configure the `file` storage backend. This backend manages DEP authentication and configuration data within plain filesystem files and directories. It has zero dependencies and and should run out of the box. The `-storage-dsn` flag specifies the filesystem directory for the database. If no `storage-dsn` is specified then `db` is used as a default.
 
 *Example:* `-storage file -storage-dsn /path/to/my/db`
 
@@ -71,7 +71,7 @@ Options are specified as a comma-separated list of "key=value" pairs. Supported 
 
 * `-storage inmem`
 
-Configure the `inmem` in-memory storage backend. This backend manages DEP authentication and configuration data entirely in volatile memory. The DSN is ignored. **WARNING: all data is lost when the server or tool process has exited.**
+Configure the `inmem` in-memory storage backend. This backend manages DEP authentication and configuration data entirely in volatile memory. There are no options and the DSN is ignored. **WARNING: all data is lost when the server or tool process has exited.**
 
 *Example:* `-storage inmem`
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -41,21 +41,30 @@ Specifies the listen address (interface and port number) for the server to liste
 
 The `-storage` and `-storage-dsn` flags together configure the storage backend. `-storage` specifies the name of backend type while `-storage-dsn` specifies the backend data source name (e.g. the connection string). If no `-storage` backend is specified then `file` is used as a default.
 
-##### diskv storage backend
-
-* `-storage diskv`
-
-Configure the `diskv` storage backend. This backend manages DEP authentication and configuration data within plain filesystem files and directories. It has zero dependencies and should run out of the box. The `-storage-dsn` flag specifies the filesystem directory for the database. If no `storage-dsn` is specified then `diskv` is used as a default.
-
-*Example:* `-storage diskv -storage-dsn /path/to/my/db`
-
 ##### file storage backend
 
 * `-storage file`
 
-Configure the `file` storage backend. This backend manages DEP authentication and configuration data within plain filesystem files and directories. It has zero dependencies and should run out of the box. The `-storage-dsn` flag specifies the filesystem directory for the database. If no `storage-dsn` is specified then `db` is used as a default.
+Configure the `file` storage backend. This backend manages DEP authentication and configuration data within plain filesystem files and directories using a key-value storage system. It has zero dependencies and should run out of the box. The `-storage-dsn` flag specifies the filesystem directory for the database. If no `storage-dsn` is specified then `dbkv` is used as a default.
+
+> [!NOTE]
+> NanoDEP versions *after* v0.4 have a new key-value based `file` backend. To use the previous version (e.g. to preserve existing data) use the `file.deprecated` backend.
 
 *Example:* `-storage file -storage-dsn /path/to/my/db`
+
+##### file.deprecated storage backend
+
+* `-storage file.deprecated`
+
+> [!WARNING]
+> The `file.deprecated` (formerly the default `file` backend) will be removed from a future NanoDEP release.
+
+Configure the `file.deprecated` storage backend. This backend manages DEP authentication and configuration data within plain filesystem files and directories. It has zero dependencies and should run out of the box. The `-storage-dsn` flag specifies the filesystem directory for the database. If no `storage-dsn` is specified then `db` is used as a default.
+
+> [!NOTE]
+> This was previously the default `file` storage backend in NanoDEP v0.4 and below. 
+
+*Example:* `-storage file.deprecated -storage-dsn /path/to/my/db`
 
 ##### in-memory storage backend
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -37,34 +37,35 @@ Enable additional debug logging.
 
 Specifies the listen address (interface and port number) for the server to listen on.
 
-#### -storage & -storage-dsn
+#### -storage, -storage-dsn, & -storage-options
 
-The `-storage` and `-storage-dsn` flags together configure the storage backend. `-storage` specifies the name of backend type while `-storage-dsn` specifies the backend data source name (e.g. the connection string). If no `-storage` backend is specified then `file` is used as a default.
+The `-storage`, `-storage-dsn`, and `-storage-options` flags together configure the storage backend. `-storage` specifies the name of backend type while `-storage-dsn` specifies the backend data source name (e.g. the connection string). The optional `-storage-options` flag specifies options for the backend if it supports them. If no `-storage` backend is specified then `filekv` is used as a default. NanoDEP versions before v0.4 defaulted to the `file` backend.
+
+##### filekv storage backend
+
+* `-storage filekv`
+
+Uses the `filekv` storage backend. This backend manages DEP authentication and configuration data within plain filesystem files and directories using a key-value storage system. It has zero dependencies, no options, and should run out of the box. The `-storage-dsn` flag specifies the filesystem directory for the database. If no `storage-dsn` is specified then `dbkv` is used as a default.
+
+*Example:* `-storage filekv -storage-dsn /path/to/my/db`
 
 ##### file storage backend
 
 * `-storage file`
 
-Configure the `file` storage backend. This backend manages DEP authentication and configuration data within plain filesystem files and directories using a key-value storage system. It has zero dependencies and should run out of the box. The `-storage-dsn` flag specifies the filesystem directory for the database. If no `storage-dsn` is specified then `dbkv` is used as a default.
+> [!WARNING]
+> The `file` storage backend is deprecated in NanoDEP v0.4 and will be removed in a future release.
 
-> [!NOTE]
-> NanoDEP versions *after* v0.4 have a new key-value based `file` backend. To use the previous version (e.g. to preserve existing data) use the `file.deprecated` backend.
+Uses the `file` storage backend. This backend manages DEP authentication and configuration data within plain filesystem files and directories. It has zero dependencies and and should run out of the box. The `-storage-dsn` flag specifies the filesystem directory for the database. If no `storage-dsn` is specified then `db` is used as a default.
 
 *Example:* `-storage file -storage-dsn /path/to/my/db`
 
-##### file.deprecated storage backend
+Options are specified as a comma-separated list of "key=value" pairs. Supported options:
 
-* `-storage file.deprecated`
+* `enable_deprecated=1`
+  * This option enables the file backend. Without this switch the `file` backend is disabled.
 
-> [!WARNING]
-> The `file.deprecated` (formerly the default `file` backend) will be removed in a future NanoDEP release.
-
-Configure the `file.deprecated` storage backend. This backend manages DEP authentication and configuration data within plain filesystem files and directories. It has zero dependencies and should run out of the box. The `-storage-dsn` flag specifies the filesystem directory for the database. If no `storage-dsn` is specified then `db` is used as a default.
-
-> [!NOTE]
-> This was previously the default `file` storage backend in NanoDEP v0.4 and below.
-
-*Example:* `-storage file.deprecated -storage-dsn /path/to/my/db`
+*Example:* `-storage file -storage-dsn /path/to/my/db -storage-options enable_deprecated=1`
 
 ##### in-memory storage backend
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,11 @@ require (
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/gomodule/oauth1 v0.2.0
 	github.com/micromdm/nanolib v0.1.1
+	github.com/peterbourgon/diskv/v3 v3.0.1
 	github.com/smallstep/pkcs7 v0.0.0-20231107075624-be1870d87d13
 )
 
-require filippo.io/edwards25519 v1.1.0 // indirect
+require (
+	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/google/btree v1.0.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/gomodule/oauth1 v0.2.0
-	github.com/micromdm/nanolib v0.1.1
+	github.com/micromdm/nanolib v0.2.0
 	github.com/peterbourgon/diskv/v3 v3.0.1
 	github.com/smallstep/pkcs7 v0.0.0-20231107075624-be1870d87d13
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/gomodule/oauth1 v0.2.0 h1:/nNHAD99yipOEspQFbAnNmwGTZ1UNXiD/+JLxwx79fo
 github.com/gomodule/oauth1 v0.2.0/go.mod h1:4r/a8/3RkhMBxJQWL5qzbOEcaQmNPIkNoI7P8sXeI08=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/micromdm/nanolib v0.1.1 h1:nNwY2xLBTHSpwEJsW5xGjkW9MdskAbeo/e6+ZYwr2mE=
-github.com/micromdm/nanolib v0.1.1/go.mod h1:FwBKCvvphgYvbdUZ+qw5kay7NHJcg6zPi8W7kXNajmE=
+github.com/micromdm/nanolib v0.2.0 h1:g5GHQuUpS82WIAB15LyenjF/0/WSUNJMe5XZfCJSXq4=
+github.com/micromdm/nanolib v0.2.0/go.mod h1:FwBKCvvphgYvbdUZ+qw5kay7NHJcg6zPi8W7kXNajmE=
 github.com/peterbourgon/diskv/v3 v3.0.1 h1:x06SQA46+PKIUftmEujdwSEpIx8kR+M9eLYsUxeYveU=
 github.com/peterbourgon/diskv/v3 v3.0.1/go.mod h1:kJ5Ny7vLdARGU3WUuy6uzO6T0nb/2gWcT1JiBvRmb5o=
 github.com/smallstep/pkcs7 v0.0.0-20231107075624-be1870d87d13 h1:qRxEt9ESQhAg1kjmgJ8oyyzlc9zkAjOooe7bcKjKORQ=

--- a/go.sum
+++ b/go.sum
@@ -4,9 +4,11 @@ github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpv
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/gomodule/oauth1 v0.2.0 h1:/nNHAD99yipOEspQFbAnNmwGTZ1UNXiD/+JLxwx79fo=
 github.com/gomodule/oauth1 v0.2.0/go.mod h1:4r/a8/3RkhMBxJQWL5qzbOEcaQmNPIkNoI7P8sXeI08=
+github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/micromdm/nanolib v0.1.1 h1:nNwY2xLBTHSpwEJsW5xGjkW9MdskAbeo/e6+ZYwr2mE=
 github.com/micromdm/nanolib v0.1.1/go.mod h1:FwBKCvvphgYvbdUZ+qw5kay7NHJcg6zPi8W7kXNajmE=
+github.com/peterbourgon/diskv/v3 v3.0.1 h1:x06SQA46+PKIUftmEujdwSEpIx8kR+M9eLYsUxeYveU=
 github.com/peterbourgon/diskv/v3 v3.0.1/go.mod h1:kJ5Ny7vLdARGU3WUuy6uzO6T0nb/2gWcT1JiBvRmb5o=
 github.com/smallstep/pkcs7 v0.0.0-20231107075624-be1870d87d13 h1:qRxEt9ESQhAg1kjmgJ8oyyzlc9zkAjOooe7bcKjKORQ=
 github.com/smallstep/pkcs7 v0.0.0-20231107075624-be1870d87d13/go.mod h1:SoUAr/4M46rZ3WaLstHxGhLEgoYIDRqxQEXLOmOEB0Y=

--- a/http/api/assigner.go
+++ b/http/api/assigner.go
@@ -46,6 +46,7 @@ func RetrieveAssignerProfileHandler(store sync.AssignerProfileRetriever, logger 
 }
 
 type AssignerProfileStorer interface {
+	// StoreAssignerProfile stores the assigner profile UUID for name (DEP name).
 	StoreAssignerProfile(ctx context.Context, name string, profileUUID string) error
 }
 

--- a/http/api/config.go
+++ b/http/api/config.go
@@ -44,6 +44,7 @@ func RetrieveConfigHandler(store client.ConfigRetriever, logger log.Logger) http
 
 type ConfigStorer interface {
 	// StoreConfig stores config for name (DEP name).
+	// The entire config is overwritten.
 	StoreConfig(ctx context.Context, name string, config *client.Config) error
 }
 

--- a/http/api/config.go
+++ b/http/api/config.go
@@ -43,7 +43,7 @@ func RetrieveConfigHandler(store client.ConfigRetriever, logger log.Logger) http
 }
 
 type ConfigStorer interface {
-	// StoreConfig stores the DEP name config for name.
+	// StoreConfig stores config for name (DEP name).
 	StoreConfig(ctx context.Context, name string, config *client.Config) error
 }
 

--- a/http/api/config.go
+++ b/http/api/config.go
@@ -43,6 +43,7 @@ func RetrieveConfigHandler(store client.ConfigRetriever, logger log.Logger) http
 }
 
 type ConfigStorer interface {
+	// StoreConfig stores the DEP name config for name.
 	StoreConfig(ctx context.Context, name string, config *client.Config) error
 }
 

--- a/http/api/tokenpki.go
+++ b/http/api/tokenpki.go
@@ -18,18 +18,28 @@ import (
 )
 
 type TokenPKIStagingRetriever interface {
+	// RetrieveStagingTokenPKI retrieves and returns the PEM bytes for the staged
+	// DEP token exchange certificate and private key for name (DEP name).
 	RetrieveStagingTokenPKI(ctx context.Context, name string) (pemCert []byte, pemKey []byte, err error)
 }
 
 type TokenPKICurrentRetriever interface {
+	// RetrieveCurrentTokenPKI reads and returns the PEM bytes for the
+	// previously-upstaged DEP token exchange certificate and private
+	// key using name (DEP name).
 	RetrieveCurrentTokenPKI(ctx context.Context, name string) (pemCert []byte, pemKey []byte, err error)
 }
 
 type TokenPKIUpstager interface {
+	// UpstageTokenPKI copies the "staging" PKI certificate and key to the current PKI certificate and key.
+	// This allows key operations to use the newly uploaded key.
+	// Note the OAuth tokens should also be changed at the same time.
 	UpstageTokenPKI(ctx context.Context, name string) error
 }
 
 type TokenPKIStorer interface {
+	// StoreTokenPKI stores the PEM bytes in pemCert and pemKey for name (DEP name).
+	// These will be stored as the "staging" set to later be "upstaged."
 	StoreTokenPKI(ctx context.Context, name string, pemCert []byte, pemKey []byte) error
 }
 

--- a/http/api/tokens.go
+++ b/http/api/tokens.go
@@ -25,6 +25,8 @@ type AuthTokensStore interface {
 }
 
 type AuthTokensStorer interface {
+	// StoreAuthTokens saves the DEP OAuth tokens for name (DEP name).
+	// Note the staging DEP certificate and key should also be upstaged at the same time.
 	StoreAuthTokens(ctx context.Context, name string, tokens *client.OAuth1Tokens) error
 }
 

--- a/storage/diskv/diskv.go
+++ b/storage/diskv/diskv.go
@@ -7,6 +7,7 @@ import (
 	"github.com/micromdm/nanodep/storage/kv"
 
 	"github.com/micromdm/nanolib/storage/kv/kvdiskv"
+	"github.com/micromdm/nanolib/storage/kv/kvtxn"
 	"github.com/peterbourgon/diskv/v3"
 )
 
@@ -17,10 +18,10 @@ type Diskv struct {
 
 func New(path string) *Diskv {
 	return &Diskv{KV: kv.New(
-		kvdiskv.New(diskv.New(diskv.Options{
+		kvtxn.New(kvdiskv.New(diskv.New(diskv.Options{
 			BasePath:     filepath.Join(path, "dep_names"),
 			Transform:    kvdiskv.FlatTransform,
 			CacheSizeMax: 1024 * 1024,
-		})),
+		}))),
 	)}
 }

--- a/storage/diskv/diskv.go
+++ b/storage/diskv/diskv.go
@@ -1,4 +1,4 @@
-// Package diskv implements an engine storage backend using the diskv key-value store.
+// Package diskv implements a NanoDEP storage backend using the diskv key-value store.
 package diskv
 
 import (
@@ -10,7 +10,7 @@ import (
 	"github.com/peterbourgon/diskv/v3"
 )
 
-// Diskv is a a diskv-backed engine storage backend.
+// Diskv is a storage backend that uses diskv.
 type Diskv struct {
 	*kv.KV
 }

--- a/storage/diskv/diskv.go
+++ b/storage/diskv/diskv.go
@@ -16,6 +16,7 @@ type Diskv struct {
 	*kv.KV
 }
 
+// New creates a new storage backend that uses diskv.
 func New(path string) *Diskv {
 	return &Diskv{KV: kv.New(
 		kvtxn.New(kvdiskv.New(diskv.New(diskv.Options{

--- a/storage/diskv/diskv.go
+++ b/storage/diskv/diskv.go
@@ -1,0 +1,26 @@
+// Package diskv implements an engine storage backend using the diskv key-value store.
+package diskv
+
+import (
+	"path/filepath"
+
+	"github.com/micromdm/nanodep/storage/kv"
+
+	"github.com/micromdm/nanolib/storage/kv/kvdiskv"
+	"github.com/peterbourgon/diskv/v3"
+)
+
+// Diskv is a a diskv-backed engine storage backend.
+type Diskv struct {
+	*kv.KV
+}
+
+func New(path string) *Diskv {
+	return &Diskv{KV: kv.New(
+		kvdiskv.New(diskv.New(diskv.Options{
+			BasePath:     filepath.Join(path, "dep_names"),
+			Transform:    kvdiskv.FlatTransform,
+			CacheSizeMax: 1024 * 1024,
+		})),
+	)}
+}

--- a/storage/diskv/diskv_test.go
+++ b/storage/diskv/diskv_test.go
@@ -1,0 +1,12 @@
+package diskv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/micromdm/nanodep/storage/test"
+)
+
+func TestFileStorage(t *testing.T) {
+	test.TestWithStorages(t, context.Background(), New(t.TempDir()))
+}

--- a/storage/file/file.go
+++ b/storage/file/file.go
@@ -62,7 +62,7 @@ func (s *FileStorage) tokenpkiFilename(name, kind string) string {
 	return path.Join(s.path, name+".tokenpki."+kind+".txt")
 }
 
-// RetrieveAuthTokens reads the JSON DEP OAuth tokens from disk for name DEP name.
+// RetrieveAuthTokens reads the JSON DEP OAuth tokens from disk for name (DEP name).
 func (s *FileStorage) RetrieveAuthTokens(_ context.Context, name string) (*client.OAuth1Tokens, error) {
 	tokens := new(client.OAuth1Tokens)
 	err := decodeJSONfile(s.tokensFilename(name), tokens)
@@ -72,7 +72,7 @@ func (s *FileStorage) RetrieveAuthTokens(_ context.Context, name string) (*clien
 	return tokens, err
 }
 
-// StoreAuthTokens saves the DEP OAuth tokens to disk as JSON for name DEP name.
+// StoreAuthTokens saves the DEP OAuth tokens to disk as JSON for name (DEP name).
 func (s *FileStorage) StoreAuthTokens(_ context.Context, name string, tokens *client.OAuth1Tokens) error {
 	f, err := os.Create(s.tokensFilename(name))
 	if err != nil {
@@ -105,7 +105,7 @@ func (s *FileStorage) RetrieveConfig(_ context.Context, name string) (*client.Co
 	return config, err
 }
 
-// StoreConfig saves the DEP config to disk as JSON for name DEP name.
+// StoreConfig saves the DEP config to disk as JSON for name (DEP name).
 func (s *FileStorage) StoreConfig(_ context.Context, name string, config *client.Config) error {
 	f, err := os.Create(s.configFilename(name))
 	if err != nil {
@@ -116,7 +116,7 @@ func (s *FileStorage) StoreConfig(_ context.Context, name string, config *client
 }
 
 // RetrieveAssignerProfile reads the assigner profile UUID and its configured
-// timestamp from disk for name DEP name.
+// timestamp from disk for name (DEP name).
 //
 // Returns an empty profile if it does not exist.
 func (s *FileStorage) RetrieveAssignerProfile(_ context.Context, name string) (string, time.Time, error) {
@@ -136,13 +136,13 @@ func (s *FileStorage) RetrieveAssignerProfile(_ context.Context, name string) (s
 	return strings.TrimSpace(string(profileBytes)), modTime, err
 }
 
-// StoreAssignerProfile saves the assigner profile UUID to disk for name DEP name.
+// StoreAssignerProfile saves the assigner profile UUID to disk for name (DEP name).
 func (s *FileStorage) StoreAssignerProfile(_ context.Context, name string, profileUUID string) error {
 	return os.WriteFile(s.profileFilename(name), []byte(profileUUID+"\n"), defaultFileMode)
 }
 
 // RetrieveCursor reads the reads the DEP fetch and sync cursor from disk
-// for name DEP name. We return an empty cursor if the cursor does not exist
+// for name (DEP name). We return an empty cursor if the cursor does not exist
 // on disk.
 func (s *FileStorage) RetrieveCursor(_ context.Context, name string) (string, error) {
 	cursorBytes, err := os.ReadFile(s.cursorFilename(name))
@@ -153,12 +153,12 @@ func (s *FileStorage) RetrieveCursor(_ context.Context, name string) (string, er
 	return strings.TrimSpace(string(cursorBytes)), err
 }
 
-// StoreCursor saves the DEP fetch and sync cursor to disk for name DEP name.
+// StoreCursor saves the DEP fetch and sync cursor to disk for name (DEP name).
 func (s *FileStorage) StoreCursor(_ context.Context, name, cursor string) error {
 	return os.WriteFile(s.cursorFilename(name), []byte(cursor+"\n"), defaultFileMode)
 }
 
-// StoreTokenPKI stores the PEM bytes in pemCert and pemKey to disk for name DEP name.
+// StoreTokenPKI stores the PEM bytes in pemCert and pemKey to disk for name (DEP name).
 func (s *FileStorage) StoreTokenPKI(_ context.Context, name string, pemCert []byte, pemKey []byte) error {
 	if err := os.WriteFile(s.tokenpkiFilename(name, "staging.cert"), pemCert, 0664); err != nil {
 		return err
@@ -204,20 +204,20 @@ func (s *FileStorage) UpstageTokenPKI(ctx context.Context, name string) error {
 }
 
 // RetrieveStagingTokenPKI reads and returns the PEM bytes for the staged
-// DEP token exchange certificate and private key from disk using name DEP name.
+// DEP token exchange certificate and private key from disk using name (DEP name).
 func (s *FileStorage) RetrieveStagingTokenPKI(ctx context.Context, name string) ([]byte, []byte, error) {
 	return s.retrieveTokenPKIExtn(name, "staging.")
 }
 
 // RetrieveCurrentTokenPKI reads and returns the PEM bytes for the previously-
 // upstaged DEP token exchange certificate and private key from disk using
-// name DEP name.
+// name (DEP name).
 func (s *FileStorage) RetrieveCurrentTokenPKI(_ context.Context, name string) ([]byte, []byte, error) {
 	return s.retrieveTokenPKIExtn(name, "")
 }
 
 // retrieveTokenPKIExtn reads and returns the PEM bytes for the DEP token exchange
-// certificate and private key from disk using name DEP name and extn type.
+// certificate and private key from disk using name (DEP name) and extn type.
 func (s *FileStorage) retrieveTokenPKIExtn(name, extn string) ([]byte, []byte, error) {
 	certBytes, err := os.ReadFile(s.tokenpkiFilename(name, extn+"cert"))
 	if err != nil {

--- a/storage/inmem/inmem.go
+++ b/storage/inmem/inmem.go
@@ -5,6 +5,7 @@ import (
 	"github.com/micromdm/nanodep/storage/kv"
 
 	"github.com/micromdm/nanolib/storage/kv/kvmap"
+	"github.com/micromdm/nanolib/storage/kv/kvtxn"
 )
 
 // InMem is an in-memory storage backend.
@@ -14,5 +15,5 @@ type InMem struct {
 
 // New creates a new storage backend.
 func New() *InMem {
-	return &InMem{KV: kv.New(kvmap.New())}
+	return &InMem{KV: kv.New(kvtxn.New(kvmap.New()))}
 }

--- a/storage/inmem/inmem.go
+++ b/storage/inmem/inmem.go
@@ -13,7 +13,7 @@ type InMem struct {
 	*kv.KV
 }
 
-// New creates a new storage backend.
+// New creates a new in-memory storage backend.
 func New() *InMem {
 	return &InMem{KV: kv.New(kvtxn.New(kvmap.New()))}
 }

--- a/storage/inmem/inmem.go
+++ b/storage/inmem/inmem.go
@@ -1,0 +1,18 @@
+// Package inmem implements an in-memory storage backend.
+package inmem
+
+import (
+	"github.com/micromdm/nanodep/storage/kv"
+
+	"github.com/micromdm/nanolib/storage/kv/kvmap"
+)
+
+// InMem is an in-memory storage backend.
+type InMem struct {
+	*kv.KV
+}
+
+// New creates a new storage backend.
+func New() *InMem {
+	return &InMem{KV: kv.New(kvmap.New())}
+}

--- a/storage/inmem/inmem.go
+++ b/storage/inmem/inmem.go
@@ -1,4 +1,4 @@
-// Package inmem implements an in-memory storage backend.
+// Package inmem implements an in-memory NanoDEP storage backend.
 package inmem
 
 import (

--- a/storage/inmem/inmem_test.go
+++ b/storage/inmem/inmem_test.go
@@ -1,0 +1,12 @@
+package inmem
+
+import (
+	"context"
+	"testing"
+
+	"github.com/micromdm/nanodep/storage/test"
+)
+
+func TestFileStorage(t *testing.T) {
+	test.TestWithStorages(t, context.Background(), New())
+}

--- a/storage/kv/kv.go
+++ b/storage/kv/kv.go
@@ -15,23 +15,23 @@ import (
 )
 
 const (
-	keySfxConsumerKey       = ".consumer_key"
-	keySfxConsumerSecret    = ".consumer_secret"
-	keySfxAccessToken       = ".access_token"
-	keySfxAccessSecret      = ".access_secret"
-	keySfxAccessTokenExpiry = ".access_token_expiry"
+	keyPfxConsumerKey       = "consumer_key."
+	keyPfxConsumerSecret    = "consumer_secret."
+	keyPfxAccessToken       = "access_token."
+	keyPfxAccessSecret      = "access_secret."
+	keyPfxAccessTokenExpiry = "access_token_expiry."
 
-	keySfxConfig = ".config"
+	keyPfxConfig = "config."
 
-	keySfxCursor = ".cursor"
+	keyPfxCursor = "cursor."
 
-	keySfxAssignerProfile        = ".assigner_profile"
-	keySfxAssignerProfileModTime = ".assigner_profile_mod_time"
+	keyPfxAssignerProfile        = "assigner_profile."
+	keyPfxAssignerProfileModTime = "assigner_profile_mod_time."
 
-	keySfxCert        = ".cert"
-	keySfxCertStaging = ".cert_staging"
-	keySfxKey         = ".key"
-	keySfxKeyStaging  = ".key_staging"
+	keyPfxCert        = "cert."
+	keyPfxCertStaging = "cert_staging."
+	keyPfxKey         = "key."
+	keyPfxKeyStaging  = "key_staging."
 )
 
 type KV struct {
@@ -50,11 +50,11 @@ func (s *KV) StoreAuthTokens(ctx context.Context, name string, tokens *client.OA
 	}
 	err = kv.PerformCRUDBucketTxn(ctx, s.b, func(ctx context.Context, txn kv.CRUDBucket) error {
 		return kv.SetMap(ctx, txn, map[string][]byte{
-			name + keySfxConsumerKey:       []byte(tokens.ConsumerKey),
-			name + keySfxConsumerSecret:    []byte(tokens.ConsumerSecret),
-			name + keySfxAccessToken:       []byte(tokens.AccessToken),
-			name + keySfxAccessSecret:      []byte(tokens.AccessSecret),
-			name + keySfxAccessTokenExpiry: expiryText,
+			keyPfxConsumerKey + name:       []byte(tokens.ConsumerKey),
+			keyPfxConsumerSecret + name:    []byte(tokens.ConsumerSecret),
+			keyPfxAccessToken + name:       []byte(tokens.AccessToken),
+			keyPfxAccessSecret + name:      []byte(tokens.AccessSecret),
+			keyPfxAccessTokenExpiry + name: expiryText,
 		})
 	})
 	return err
@@ -66,11 +66,11 @@ func (s *KV) RetrieveAuthTokens(ctx context.Context, name string) (*client.OAuth
 	err := kv.PerformCRUDBucketTxn(ctx, s.b, func(ctx context.Context, txn kv.CRUDBucket) error {
 		var err error
 		tokenMap, err = kv.GetMap(ctx, s.b, []string{
-			name + keySfxConsumerKey,
-			name + keySfxConsumerSecret,
-			name + keySfxAccessToken,
-			name + keySfxAccessSecret,
-			name + keySfxAccessTokenExpiry,
+			keyPfxConsumerKey + name,
+			keyPfxConsumerSecret + name,
+			keyPfxAccessToken + name,
+			keyPfxAccessSecret + name,
+			keyPfxAccessTokenExpiry + name,
 		})
 		return err
 	})
@@ -80,12 +80,12 @@ func (s *KV) RetrieveAuthTokens(ctx context.Context, name string) (*client.OAuth
 		return nil, err
 	}
 	tokens := &client.OAuth1Tokens{
-		ConsumerKey:    string(tokenMap[name+keySfxConsumerKey]),
-		ConsumerSecret: string(tokenMap[name+keySfxConsumerSecret]),
-		AccessToken:    string(tokenMap[name+keySfxAccessToken]),
-		AccessSecret:   string(tokenMap[name+keySfxAccessSecret]),
+		ConsumerKey:    string(tokenMap[keyPfxConsumerKey+name]),
+		ConsumerSecret: string(tokenMap[keyPfxConsumerSecret+name]),
+		AccessToken:    string(tokenMap[keyPfxAccessToken+name]),
+		AccessSecret:   string(tokenMap[keyPfxAccessSecret+name]),
 	}
-	return tokens, tokens.AccessTokenExpiry.UnmarshalText(tokenMap[name+keySfxAccessTokenExpiry])
+	return tokens, tokens.AccessTokenExpiry.UnmarshalText(tokenMap[keyPfxAccessTokenExpiry+name])
 }
 
 // StoreConfig stores the config for name (DEP name), overwriting it.
@@ -95,14 +95,14 @@ func (s *KV) StoreConfig(ctx context.Context, name string, config *client.Config
 		return err
 	}
 	// auto-commit of storage obviates need for txn for single key
-	return s.b.Set(ctx, name+keySfxConfig, configJSON)
+	return s.b.Set(ctx, keyPfxConfig+name, configJSON)
 }
 
 // RetrieveConfig retrieves config of name (DEP name).
 // If the DEP name or config does not exist then a nil config and
 // nil error will be returned.
 func (s *KV) RetrieveConfig(ctx context.Context, name string) (*client.Config, error) {
-	configJSON, err := s.b.Get(ctx, name+keySfxConfig)
+	configJSON, err := s.b.Get(ctx, keyPfxConfig+name)
 	if errors.Is(err, kv.ErrKeyNotFound) {
 		return nil, nil
 	} else if err != nil {
@@ -120,8 +120,8 @@ func (s *KV) StoreAssignerProfile(ctx context.Context, name string, profileUUID 
 	}
 	err = kv.PerformCRUDBucketTxn(ctx, s.b, func(ctx context.Context, txn kv.CRUDBucket) error {
 		return kv.SetMap(ctx, txn, map[string][]byte{
-			name + keySfxAssignerProfile:        []byte(profileUUID),
-			name + keySfxAssignerProfileModTime: modTimeText,
+			keyPfxAssignerProfile + name:        []byte(profileUUID),
+			keyPfxAssignerProfileModTime + name: modTimeText,
 		})
 	})
 	return err
@@ -135,8 +135,8 @@ func (s *KV) RetrieveAssignerProfile(ctx context.Context, name string) (string, 
 	err := kv.PerformCRUDBucketTxn(ctx, s.b, func(ctx context.Context, txn kv.CRUDBucket) error {
 		var err error
 		profileMap, err = kv.GetMap(ctx, s.b, []string{
-			name + keySfxAssignerProfile,
-			name + keySfxAssignerProfileModTime,
+			keyPfxAssignerProfile + name,
+			keyPfxAssignerProfileModTime + name,
 		})
 		return err
 	})
@@ -144,15 +144,15 @@ func (s *KV) RetrieveAssignerProfile(ctx context.Context, name string) (string, 
 	if errors.Is(err, kv.ErrKeyNotFound) {
 		return "", modTime, nil
 	}
-	return string(profileMap[name+keySfxAssignerProfile]),
+	return string(profileMap[keyPfxAssignerProfile+name]),
 		modTime,
-		modTime.UnmarshalText(profileMap[name+keySfxAssignerProfileModTime])
+		modTime.UnmarshalText(profileMap[keyPfxAssignerProfileModTime+name])
 }
 
 // RetrieveCursor retrieves the cursor for name (DEP name).
 // If the DEP name or cursor does not exist an empty cursor and nil error will be returned.
 func (s *KV) RetrieveCursor(ctx context.Context, name string) (string, error) {
-	cursor, err := s.b.Get(ctx, name+keySfxCursor)
+	cursor, err := s.b.Get(ctx, keyPfxCursor+name)
 	if errors.Is(err, kv.ErrKeyNotFound) {
 		return "", nil
 	}
@@ -162,15 +162,15 @@ func (s *KV) RetrieveCursor(ctx context.Context, name string) (string, error) {
 // StoreCursor stores the cursor for name (DEP name).
 func (s *KV) StoreCursor(ctx context.Context, name, cursor string) error {
 	// auto-commit of storage obviates need for txn for single key
-	return s.b.Set(ctx, name+keySfxCursor, []byte(cursor))
+	return s.b.Set(ctx, keyPfxCursor+name, []byte(cursor))
 }
 
 // StoreTokenPKI stores the PEM bytes in pemCert and pemKey for name (DEP name).
 func (s *KV) StoreTokenPKI(ctx context.Context, name string, pemCert []byte, pemKey []byte) error {
 	return kv.PerformCRUDBucketTxn(ctx, s.b, func(ctx context.Context, txn kv.CRUDBucket) error {
 		return kv.SetMap(ctx, txn, map[string][]byte{
-			name + keySfxCertStaging: pemCert,
-			name + keySfxKeyStaging:  pemKey,
+			keyPfxCertStaging + name: pemCert,
+			keyPfxKeyStaging + name:  pemKey,
 		})
 	})
 }
@@ -180,15 +180,15 @@ func (s *KV) StoreTokenPKI(ctx context.Context, name string, pemCert []byte, pem
 func (s *KV) UpstageTokenPKI(ctx context.Context, name string) error {
 	err := kv.PerformCRUDBucketTxn(ctx, s.b, func(ctx context.Context, txn kv.CRUDBucket) error {
 		tokenPKIMap, err := kv.GetMap(ctx, txn, []string{
-			name + keySfxCertStaging,
-			name + keySfxKeyStaging,
+			keyPfxCertStaging + name,
+			keyPfxKeyStaging + name,
 		})
 		if err != nil {
 			return err
 		}
 		return kv.SetMap(ctx, txn, map[string][]byte{
-			name + keySfxCert: tokenPKIMap[name+keySfxCertStaging],
-			name + keySfxKey:  tokenPKIMap[name+keySfxKeyStaging],
+			keyPfxCert + name: tokenPKIMap[keyPfxCertStaging+name],
+			keyPfxKey + name:  tokenPKIMap[keyPfxKeyStaging+name],
 		})
 	})
 	return err
@@ -201,8 +201,8 @@ func (s *KV) RetrieveStagingTokenPKI(ctx context.Context, name string) ([]byte, 
 	err := kv.PerformCRUDBucketTxn(ctx, s.b, func(ctx context.Context, txn kv.CRUDBucket) error {
 		var err error
 		tokenPKIMap, err = kv.GetMap(ctx, s.b, []string{
-			name + keySfxCertStaging,
-			name + keySfxKeyStaging,
+			keyPfxCertStaging + name,
+			keyPfxKeyStaging + name,
 		})
 		return err
 	})
@@ -211,7 +211,7 @@ func (s *KV) RetrieveStagingTokenPKI(ctx context.Context, name string) ([]byte, 
 	} else if err != nil {
 		return nil, nil, err
 	}
-	return tokenPKIMap[name+keySfxCertStaging], tokenPKIMap[name+keySfxKeyStaging], nil
+	return tokenPKIMap[keyPfxCertStaging+name], tokenPKIMap[keyPfxKeyStaging+name], nil
 }
 
 // RetrieveCurrentTokenPKI reads and returns the PEM bytes for the
@@ -222,8 +222,8 @@ func (s *KV) RetrieveCurrentTokenPKI(ctx context.Context, name string) ([]byte, 
 	err := kv.PerformCRUDBucketTxn(ctx, s.b, func(ctx context.Context, txn kv.CRUDBucket) error {
 		var err error
 		tokenPKIMap, err = kv.GetMap(ctx, s.b, []string{
-			name + keySfxCert,
-			name + keySfxKey,
+			keyPfxCert + name,
+			keyPfxKey + name,
 		})
 		return err
 	})
@@ -232,5 +232,5 @@ func (s *KV) RetrieveCurrentTokenPKI(ctx context.Context, name string) ([]byte, 
 	} else if err != nil {
 		return nil, nil, err
 	}
-	return tokenPKIMap[name+keySfxCert], tokenPKIMap[name+keySfxKey], nil
+	return tokenPKIMap[keyPfxCert+name], tokenPKIMap[keyPfxKey+name], nil
 }

--- a/storage/kv/kv.go
+++ b/storage/kv/kv.go
@@ -1,0 +1,205 @@
+// Package kv implements a NanoDEP storage backend using a key-value store.
+package kv
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/micromdm/nanodep/client"
+	"github.com/micromdm/nanodep/storage"
+
+	"github.com/micromdm/nanolib/storage/kv"
+)
+
+const (
+	keySfxConsumerKey       = ".consumer_key"
+	keySfxConsumerSecret    = ".consumer_secret"
+	keySfxAccessToken       = ".access_token"
+	keySfxAccessSecret      = ".access_secret"
+	keySfxAccessTokenExpiry = ".access_token_expiry"
+
+	keySfxConfig = ".config"
+
+	keySfxCursor = ".cursor"
+
+	keySfxAssignerProfile        = ".assigner_profile"
+	keySfxAssignerProfileModTime = ".assigner_profile_mod_time"
+
+	keySfxCert        = ".cert"
+	keySfxCertStaging = ".cert_staging"
+	keySfxKey         = ".key"
+	keySfxKeyStaging  = ".key_staging"
+)
+
+type KV struct {
+	b kv.Bucket
+}
+
+func New(b kv.Bucket) *KV {
+	return &KV{b: b}
+}
+
+// StoreAuthTokens saves the DEP OAuth tokens to disk as JSON for name DEP name.
+func (s *KV) StoreAuthTokens(ctx context.Context, name string, tokens *client.OAuth1Tokens) error {
+	expiryText, err := tokens.AccessTokenExpiry.MarshalText()
+	if err != nil {
+		return err
+	}
+	return kv.SetMap(ctx, s.b, map[string][]byte{
+		name + keySfxConsumerKey:       []byte(tokens.ConsumerKey),
+		name + keySfxConsumerSecret:    []byte(tokens.ConsumerSecret),
+		name + keySfxAccessToken:       []byte(tokens.AccessToken),
+		name + keySfxAccessSecret:      []byte(tokens.AccessSecret),
+		name + keySfxAccessTokenExpiry: expiryText,
+	})
+}
+
+// RetrieveAuthTokens reads the JSON DEP OAuth tokens from disk for name DEP name.
+func (s *KV) RetrieveAuthTokens(ctx context.Context, name string) (*client.OAuth1Tokens, error) {
+	tokenMap, err := kv.GetMap(ctx, s.b, []string{
+		name + keySfxConsumerKey,
+		name + keySfxConsumerSecret,
+		name + keySfxAccessToken,
+		name + keySfxAccessSecret,
+		name + keySfxAccessTokenExpiry,
+	})
+	if errors.Is(err, kv.ErrKeyNotFound) {
+		return nil, fmt.Errorf("%w: %v", storage.ErrNotFound, err)
+	} else if err != nil {
+		return nil, err
+	}
+	tokens := &client.OAuth1Tokens{
+		ConsumerKey:    string(tokenMap[name+keySfxConsumerKey]),
+		ConsumerSecret: string(tokenMap[name+keySfxConsumerSecret]),
+		AccessToken:    string(tokenMap[name+keySfxAccessToken]),
+		AccessSecret:   string(tokenMap[name+keySfxAccessSecret]),
+	}
+	return tokens, tokens.AccessTokenExpiry.UnmarshalText(tokenMap[name+keySfxAccessTokenExpiry])
+}
+
+// StoreConfig saves the DEP config to disk as JSON for name DEP name.
+func (s *KV) StoreConfig(ctx context.Context, name string, config *client.Config) error {
+	configJSON, err := json.Marshal(config)
+	if err != nil {
+		return err
+	}
+	return s.b.Set(ctx, name+keySfxConfig, configJSON)
+}
+
+// RetrieveConfig reads the JSON DEP config of a DEP name.
+//
+// Returns (nil, nil) if the DEP name does not exist, or if the config
+// for the DEP name does not exist.
+func (s *KV) RetrieveConfig(ctx context.Context, name string) (*client.Config, error) {
+	configJSON, err := s.b.Get(ctx, name+keySfxConfig)
+	if errors.Is(err, kv.ErrKeyNotFound) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	config := new(client.Config)
+	return config, json.Unmarshal(configJSON, config)
+}
+
+// StoreAssignerProfile saves the assigner profile UUID to disk for name DEP name.
+func (s *KV) StoreAssignerProfile(ctx context.Context, name string, profileUUID string) error {
+	modTimeText, err := time.Now().UTC().MarshalText()
+	if err != nil {
+		return err
+	}
+	return kv.SetMap(ctx, s.b, map[string][]byte{
+		name + keySfxAssignerProfile:        []byte(profileUUID),
+		name + keySfxAssignerProfileModTime: modTimeText,
+	})
+}
+
+// RetrieveAssignerProfile reads the assigner profile UUID and its configured
+// timestamp from disk for name DEP name.
+//
+// Returns an empty profile if it does not exist.
+func (s *KV) RetrieveAssignerProfile(ctx context.Context, name string) (string, time.Time, error) {
+	profileMap, err := kv.GetMap(ctx, s.b, []string{
+		name + keySfxAssignerProfile,
+		name + keySfxAssignerProfileModTime,
+	})
+	var modTime time.Time
+	if errors.Is(err, kv.ErrKeyNotFound) {
+		return "", modTime, nil
+	}
+	return string(profileMap[name+keySfxAssignerProfile]),
+		modTime,
+		modTime.UnmarshalText(profileMap[name+keySfxAssignerProfileModTime])
+}
+
+// RetrieveCursor retrieves the cursor from the key-value store for name DEP name.
+// If the DEP name or cursor does not exist an empty cursor and nil error is be returned.
+func (s *KV) RetrieveCursor(ctx context.Context, name string) (string, error) {
+	cursor, err := s.b.Get(ctx, name+keySfxCursor)
+	if errors.Is(err, kv.ErrKeyNotFound) {
+		return "", nil
+	}
+	return string(cursor), err
+}
+
+// StoreCursor stores the cursor to disk for name DEP name.
+func (s *KV) StoreCursor(ctx context.Context, name, cursor string) error {
+	return s.b.Set(ctx, name+keySfxCursor, []byte(cursor))
+}
+
+// StoreTokenPKI stores the PEM bytes in pemCert and pemKey to disk for name DEP name.
+func (s *KV) StoreTokenPKI(ctx context.Context, name string, pemCert []byte, pemKey []byte) error {
+	return kv.SetMap(ctx, s.b, map[string][]byte{
+		name + keySfxCertStaging: pemCert,
+		name + keySfxKeyStaging:  pemKey,
+	})
+}
+
+// UpstageTokenPKI copies the staging PKI certificate and key to the current PKI certificate and key.
+// Warning: this operation is not atomic.
+func (s *KV) UpstageTokenPKI(ctx context.Context, name string) error {
+	tokenPKIMap, err := kv.GetMap(ctx, s.b, []string{
+		name + keySfxCertStaging,
+		name + keySfxKeyStaging,
+	})
+	if err != nil {
+		return nil
+	}
+	return kv.SetMap(ctx, s.b, map[string][]byte{
+		name + keySfxCert: tokenPKIMap[name+keySfxCertStaging],
+		name + keySfxKey:  tokenPKIMap[name+keySfxKeyStaging],
+	})
+}
+
+// RetrieveStagingTokenPKI reads and returns the PEM bytes for the staged
+// DEP token exchange certificate and private key from disk using name DEP name.
+func (s *KV) RetrieveStagingTokenPKI(ctx context.Context, name string) ([]byte, []byte, error) {
+	tokenPKIMap, err := kv.GetMap(ctx, s.b, []string{
+		name + keySfxCertStaging,
+		name + keySfxKeyStaging,
+	})
+	if errors.Is(err, kv.ErrKeyNotFound) {
+		return nil, nil, fmt.Errorf("%w: %v", storage.ErrNotFound, err)
+	} else if err != nil {
+		return nil, nil, err
+	}
+	return tokenPKIMap[name+keySfxCertStaging], tokenPKIMap[name+keySfxKeyStaging], nil
+}
+
+// RetrieveCurrentTokenPKI reads and returns the PEM bytes for the previously-
+// upstaged DEP token exchange certificate and private key from disk using
+// name DEP name.
+func (s *KV) RetrieveCurrentTokenPKI(ctx context.Context, name string) ([]byte, []byte, error) {
+	tokenPKIMap, err := kv.GetMap(ctx, s.b, []string{
+		name + keySfxCert,
+		name + keySfxKey,
+	})
+	if errors.Is(err, kv.ErrKeyNotFound) {
+		return nil, nil, fmt.Errorf("%w: %v", storage.ErrNotFound, err)
+	} else if err != nil {
+		return nil, nil, err
+	}
+	return tokenPKIMap[name+keySfxCert], tokenPKIMap[name+keySfxKey], nil
+}

--- a/storage/kv/kv.go
+++ b/storage/kv/kv.go
@@ -42,7 +42,7 @@ func New(b kv.Bucket) *KV {
 	return &KV{b: b}
 }
 
-// StoreAuthTokens saves the DEP OAuth tokens to disk as JSON for name DEP name.
+// StoreAuthTokens stores the DEP OAuth tokens for name (DEP name).
 func (s *KV) StoreAuthTokens(ctx context.Context, name string, tokens *client.OAuth1Tokens) error {
 	expiryText, err := tokens.AccessTokenExpiry.MarshalText()
 	if err != nil {
@@ -57,7 +57,7 @@ func (s *KV) StoreAuthTokens(ctx context.Context, name string, tokens *client.OA
 	})
 }
 
-// RetrieveAuthTokens reads the JSON DEP OAuth tokens from disk for name DEP name.
+// RetrieveAuthTokens retrieves the OAuth tokens for name (DEP name).
 func (s *KV) RetrieveAuthTokens(ctx context.Context, name string) (*client.OAuth1Tokens, error) {
 	tokenMap, err := kv.GetMap(ctx, s.b, []string{
 		name + keySfxConsumerKey,
@@ -80,7 +80,7 @@ func (s *KV) RetrieveAuthTokens(ctx context.Context, name string) (*client.OAuth
 	return tokens, tokens.AccessTokenExpiry.UnmarshalText(tokenMap[name+keySfxAccessTokenExpiry])
 }
 
-// StoreConfig saves the DEP config to disk as JSON for name DEP name.
+// StoreConfig stores the config for name (DEP name).
 func (s *KV) StoreConfig(ctx context.Context, name string, config *client.Config) error {
 	configJSON, err := json.Marshal(config)
 	if err != nil {
@@ -89,10 +89,9 @@ func (s *KV) StoreConfig(ctx context.Context, name string, config *client.Config
 	return s.b.Set(ctx, name+keySfxConfig, configJSON)
 }
 
-// RetrieveConfig reads the JSON DEP config of a DEP name.
-//
-// Returns (nil, nil) if the DEP name does not exist, or if the config
-// for the DEP name does not exist.
+// RetrieveConfig retrieves config of name (DEP name).
+// If the DEP name or config does not exist then a nil config and
+// nil error will be returned.
 func (s *KV) RetrieveConfig(ctx context.Context, name string) (*client.Config, error) {
 	configJSON, err := s.b.Get(ctx, name+keySfxConfig)
 	if errors.Is(err, kv.ErrKeyNotFound) {
@@ -104,7 +103,7 @@ func (s *KV) RetrieveConfig(ctx context.Context, name string) (*client.Config, e
 	return config, json.Unmarshal(configJSON, config)
 }
 
-// StoreAssignerProfile saves the assigner profile UUID to disk for name DEP name.
+// StoreAssignerProfile stores the assigner profile UUID for name (DEP name).
 func (s *KV) StoreAssignerProfile(ctx context.Context, name string, profileUUID string) error {
 	modTimeText, err := time.Now().UTC().MarshalText()
 	if err != nil {
@@ -116,9 +115,8 @@ func (s *KV) StoreAssignerProfile(ctx context.Context, name string, profileUUID 
 	})
 }
 
-// RetrieveAssignerProfile reads the assigner profile UUID and its configured
-// timestamp from disk for name DEP name.
-//
+// RetrieveAssignerProfile retrieves the assigner profile UUID and its
+// configured timestamp name (DEP name).
 // Returns an empty profile if it does not exist.
 func (s *KV) RetrieveAssignerProfile(ctx context.Context, name string) (string, time.Time, error) {
 	profileMap, err := kv.GetMap(ctx, s.b, []string{
@@ -134,8 +132,8 @@ func (s *KV) RetrieveAssignerProfile(ctx context.Context, name string) (string, 
 		modTime.UnmarshalText(profileMap[name+keySfxAssignerProfileModTime])
 }
 
-// RetrieveCursor retrieves the cursor from the key-value store for name DEP name.
-// If the DEP name or cursor does not exist an empty cursor and nil error is be returned.
+// RetrieveCursor retrieves the cursor for name (DEP name).
+// If the DEP name or cursor does not exist an empty cursor and nil error will be returned.
 func (s *KV) RetrieveCursor(ctx context.Context, name string) (string, error) {
 	cursor, err := s.b.Get(ctx, name+keySfxCursor)
 	if errors.Is(err, kv.ErrKeyNotFound) {
@@ -144,12 +142,12 @@ func (s *KV) RetrieveCursor(ctx context.Context, name string) (string, error) {
 	return string(cursor), err
 }
 
-// StoreCursor stores the cursor to disk for name DEP name.
+// StoreCursor stores the cursor for name (DEP name).
 func (s *KV) StoreCursor(ctx context.Context, name, cursor string) error {
 	return s.b.Set(ctx, name+keySfxCursor, []byte(cursor))
 }
 
-// StoreTokenPKI stores the PEM bytes in pemCert and pemKey to disk for name DEP name.
+// StoreTokenPKI stores the PEM bytes in pemCert and pemKey for name (DEP name).
 func (s *KV) StoreTokenPKI(ctx context.Context, name string, pemCert []byte, pemKey []byte) error {
 	return kv.SetMap(ctx, s.b, map[string][]byte{
 		name + keySfxCertStaging: pemCert,
@@ -173,8 +171,8 @@ func (s *KV) UpstageTokenPKI(ctx context.Context, name string) error {
 	})
 }
 
-// RetrieveStagingTokenPKI reads and returns the PEM bytes for the staged
-// DEP token exchange certificate and private key from disk using name DEP name.
+// RetrieveStagingTokenPKI retrieves and returns the PEM bytes for the staged
+// DEP token exchange certificate and private key using name (DEP name).
 func (s *KV) RetrieveStagingTokenPKI(ctx context.Context, name string) ([]byte, []byte, error) {
 	tokenPKIMap, err := kv.GetMap(ctx, s.b, []string{
 		name + keySfxCertStaging,
@@ -188,9 +186,9 @@ func (s *KV) RetrieveStagingTokenPKI(ctx context.Context, name string) ([]byte, 
 	return tokenPKIMap[name+keySfxCertStaging], tokenPKIMap[name+keySfxKeyStaging], nil
 }
 
-// RetrieveCurrentTokenPKI reads and returns the PEM bytes for the previously-
-// upstaged DEP token exchange certificate and private key from disk using
-// name DEP name.
+// RetrieveCurrentTokenPKI reads and returns the PEM bytes for the
+// previously-upstaged DEP token exchange certificate and private key
+// using name (DEP name).
 func (s *KV) RetrieveCurrentTokenPKI(ctx context.Context, name string) ([]byte, []byte, error) {
 	tokenPKIMap, err := kv.GetMap(ctx, s.b, []string{
 		name + keySfxCert,

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -80,7 +80,7 @@ func New(opts ...Option) (*MySQLStorage, error) {
 
 const timestampFormat = "2006-01-02 15:04:05"
 
-// RetrieveAuthTokens reads the DEP OAuth tokens for name DEP name.
+// RetrieveAuthTokens reads the DEP OAuth tokens for name (DEP name).
 func (s *MySQLStorage) RetrieveAuthTokens(ctx context.Context, name string) (*client.OAuth1Tokens, error) {
 	tokenRow, err := s.q.GetAuthTokens(ctx, name)
 	if err != nil {
@@ -151,7 +151,7 @@ func (s *MySQLStorage) RetrieveConfig(ctx context.Context, name string) (*client
 	}, nil
 }
 
-// StoreConfig saves the DEP config for name DEP name.
+// StoreConfig saves the DEP config for name (DEP name).
 func (s *MySQLStorage) StoreConfig(ctx context.Context, name string, config *client.Config) error {
 	_, err := s.db.ExecContext(
 		ctx, `
@@ -167,7 +167,7 @@ ON DUPLICATE KEY UPDATE
 	return err
 }
 
-// RetrieveAssignerProfile reads the assigner profile UUID and its timestamp for name DEP name.
+// RetrieveAssignerProfile reads the assigner profile UUID and its timestamp for name (DEP name).
 //
 // Returns an empty profile UUID if it does not exist.
 func (s *MySQLStorage) RetrieveAssignerProfile(ctx context.Context, name string) (profileUUID string, modTime time.Time, err error) {
@@ -188,7 +188,7 @@ func (s *MySQLStorage) RetrieveAssignerProfile(ctx context.Context, name string)
 	return
 }
 
-// StoreAssignerProfile saves the assigner profile UUID for name DEP name.
+// StoreAssignerProfile saves the assigner profile UUID for name (DEP name).
 func (s *MySQLStorage) StoreAssignerProfile(ctx context.Context, name string, profileUUID string) error {
 	_, err := s.db.ExecContext(
 		ctx, `
@@ -205,7 +205,7 @@ ON DUPLICATE KEY UPDATE
 	return err
 }
 
-// RetrieveCursor reads the reads the DEP fetch and sync cursor for name DEP name.
+// RetrieveCursor reads the reads the DEP fetch and sync cursor for name (DEP name).
 //
 // Returns an empty cursor if the cursor does not exist.
 func (s *MySQLStorage) RetrieveCursor(ctx context.Context, name string) (string, error) {
@@ -222,7 +222,7 @@ func (s *MySQLStorage) RetrieveCursor(ctx context.Context, name string) (string,
 	return cursor.String, nil
 }
 
-// StoreCursor saves the DEP fetch and sync cursor for name DEP name.
+// StoreCursor saves the DEP fetch and sync cursor for name (DEP name).
 func (s *MySQLStorage) StoreCursor(ctx context.Context, name, cursor string) error {
 	_, err := s.db.ExecContext(
 		ctx, `
@@ -238,7 +238,7 @@ ON DUPLICATE KEY UPDATE
 	return err
 }
 
-// StoreTokenPKI stores the staging PEM bytes in pemCert and pemKey for name DEP name.
+// StoreTokenPKI stores the staging PEM bytes in pemCert and pemKey for name (DEP name).
 func (s *MySQLStorage) StoreTokenPKI(ctx context.Context, name string, pemCert []byte, pemKey []byte) error {
 	_, err := s.db.ExecContext(
 		ctx, `
@@ -267,7 +267,7 @@ func (s *MySQLStorage) UpstageTokenPKI(ctx context.Context, name string) error {
 }
 
 // RetrieveStagingTokenPKI returns the PEM bytes for the staged DEP
-// token exchange certificate and private key using name DEP name.
+// token exchange certificate and private key using name (DEP name).
 func (s *MySQLStorage) RetrieveStagingTokenPKI(ctx context.Context, name string) ([]byte, []byte, error) {
 	keypair, err := s.q.GetStagingKeypair(ctx, name)
 	if err != nil {
@@ -283,7 +283,7 @@ func (s *MySQLStorage) RetrieveStagingTokenPKI(ctx context.Context, name string)
 }
 
 // RetrieveCurrentTokenPKI returns the PEM bytes for the previously-upstaged DEP
-// token exchange certificate and private key using name DEP name.
+// token exchange certificate and private key using name (DEP name).
 func (s *MySQLStorage) RetrieveCurrentTokenPKI(ctx context.Context, name string) (pemCert []byte, pemKey []byte, err error) {
 	keypair, err := s.q.GetCurrentKeypair(ctx, name)
 	if err != nil {

--- a/sync/assigner.go
+++ b/sync/assigner.go
@@ -13,6 +13,8 @@ import (
 )
 
 type AssignerProfileRetriever interface {
+	// RetrieveAssignerProfile retrieves the assigner profile UUID and timestamp for name DEP name.
+	// If name or assigner profile UUID do not exist returns an empty profile and nil error.
 	RetrieveAssignerProfile(ctx context.Context, name string) (profileUUID string, modTime time.Time, err error)
 }
 

--- a/sync/assigner.go
+++ b/sync/assigner.go
@@ -13,7 +13,7 @@ import (
 )
 
 type AssignerProfileRetriever interface {
-	// RetrieveAssignerProfile retrieves the assigner profile UUID and timestamp for name DEP name.
+	// RetrieveAssignerProfile retrieves the assigner profile UUID and timestamp for name (DEP name).
 	// If name or assigner profile UUID do not exist returns an empty profile and nil error.
 	RetrieveAssignerProfile(ctx context.Context, name string) (profileUUID string, modTime time.Time, err error)
 }

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -15,11 +15,11 @@ import (
 
 // CursorStorage stores and retrieves fetch and sync cursors.
 type CursorStorage interface {
-	// RetrieveCursor retrieves the cursor from storage for name DEP name.
+	// RetrieveCursor retrieves the cursor from storage for name (DEP name).
 	// If the DEP name or cursor does not exist an empty cursor and nil error should be returned.
 	RetrieveCursor(ctx context.Context, name string) (string, error)
 
-	// StoreCursor stores the cursor to disk for name DEP name.
+	// StoreCursor stores the cursor to disk for name (DEP name).
 	StoreCursor(ctx context.Context, name string, cursor string) error
 }
 

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -13,10 +13,13 @@ import (
 	"github.com/micromdm/nanolib/log/ctxlog"
 )
 
-// CursorStorage is where the device fetch and sync cursor can be stored and
-// retrieved for a given DEP name.
+// CursorStorage stores and retrieves fetch and sync cursors.
 type CursorStorage interface {
+	// RetrieveCursor retrieves the cursor from storage for name DEP name.
+	// If the DEP name or cursor does not exist an empty cursor and nil error should be returned.
 	RetrieveCursor(ctx context.Context, name string) (string, error)
+
+	// StoreCursor stores the cursor to disk for name DEP name.
 	StoreCursor(ctx context.Context, name string, cursor string) error
 }
 


### PR DESCRIPTION
Implements a NanoLIB kv-compatible storage backend which then backs the new `inmem` and `filekv` backends. The existing `file` backend is deprecated. See the [operations guide](https://github.com/micromdm/nanodep/blob/main/docs/operations-guide.md) changes for further guidance.