### PR TITLE
fix: pass dep name through params in callback

### DIFF
--- a/cmd/depsyncer/main.go
+++ b/cmd/depsyncer/main.go
@@ -151,12 +151,12 @@ func main() {
 				}
 			}()
 			if webhook != nil {
-				go func() {
+				go func(name string) {
 					err := webhook.CallWebhook(ctx, name, isFetch, resp)
 					if err != nil {
 						logger.Info("msg", "calling webhook", "err", err)
 					}
-				}()
+				}(name)
 			}
 			return nil
 		}


### PR DESCRIPTION
fixes #69 

although i think Go 1.22 fixes the behavior that causes this in the lang (https://go.dev/blog/go1.22)