### PR TITLE
add and use slog adapter

### DIFF
--- a/cmd/depserver/main.go
+++ b/cmd/depserver/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	stdlog "log"
+	stdslog "log/slog"
 	"math/rand"
 	"net/http"
 	"os"
@@ -13,11 +13,12 @@ import (
 	"github.com/micromdm/nanodep/client"
 	dephttp "github.com/micromdm/nanodep/http"
 	"github.com/micromdm/nanodep/http/api"
+	"github.com/micromdm/nanodep/log/caller"
+	"github.com/micromdm/nanodep/log/slog"
 	"github.com/micromdm/nanodep/proxy"
 
 	"github.com/google/uuid"
 	"github.com/micromdm/nanolib/envflag"
-	"github.com/micromdm/nanolib/log/stdlogfmt"
 )
 
 // overridden by -ldflags -X
@@ -59,10 +60,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	logger := stdlogfmt.New(
-		stdlogfmt.WithLogger(stdlog.Default()),
-		stdlogfmt.WithDebugFlag(*flDebug),
-	)
+	level := stdslog.LevelInfo
+	if *flDebug {
+		level = stdslog.LevelDebug
+	}
+	logger := caller.New(slog.New(stdslog.New(stdslog.NewTextHandler(os.Stdout, &stdslog.HandlerOptions{Level: level}))))
 
 	storage, err := cli.Storage(*flStorage, *flDSN, *flOptions)
 	if err != nil {

--- a/log/caller/caller.go
+++ b/log/caller/caller.go
@@ -1,0 +1,65 @@
+package caller
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+
+	"github.com/micromdm/nanolib/log"
+)
+
+// Logger wraps another logger and adds callsite information to the logs.
+// Be careful about placement and usage of this logger as correct
+// reporting of the callsite depends on call depth/stack frame location.
+type Logger struct {
+	logger log.Logger
+	lctx   []interface{}
+	skip   int
+}
+
+type Option func(*Logger)
+
+// WithSkip skips over any additional stack frames.
+// The argument skip is the number of additional stack frames to ascend.
+// This option is unnecessary if this logger is the "top" of the logging stack.
+func WithSkip(skip int) Option {
+	return func(l *Logger) {
+		l.skip = skip
+	}
+}
+
+func New(logger log.Logger, opts ...Option) *Logger {
+	if logger == nil {
+		panic("nil logger")
+	}
+	l := &Logger{logger: logger}
+	for _, opt := range opts {
+		opt(l)
+	}
+	return l
+}
+
+// caller returns filename:lineno
+func caller(skip int) string {
+	_, filename, line, _ := runtime.Caller(skip + 1) // skip past *this* func
+	return fmt.Sprintf("%s:%d", filepath.Base(filename), line)
+}
+
+// Info logs at the info level with caller info.
+func (logger *Logger) Info(logs ...interface{}) {
+	logs = append(logs, "caller", caller(logger.skip+1))
+	logger.logger.Info(append(logger.lctx, logs...)...)
+}
+
+// Debug logs at the debug level with caller info.
+func (logger *Logger) Debug(logs ...interface{}) {
+	logs = append(logs, "caller", caller(logger.skip+1))
+	logger.logger.Debug(append(logger.lctx, logs...)...)
+}
+
+// With returns a logger with additoinal context.
+func (logger *Logger) With(logs ...interface{}) log.Logger {
+	logger2 := *logger
+	logger2.lctx = append(logger2.lctx, logs...)
+	return &logger2
+}

--- a/log/slog/slog.go
+++ b/log/slog/slog.go
@@ -1,0 +1,57 @@
+package slog
+
+import (
+	"log/slog"
+
+	"github.com/micromdm/nanolib/log"
+)
+
+// Logger wraps stdlib slog for logging.
+type Logger struct {
+	lctx    []any
+	slogger *slog.Logger
+}
+
+func New(slogger *slog.Logger) *Logger {
+	if slogger == nil {
+		panic("nil slogger")
+	}
+	return &Logger{slogger: slogger}
+}
+
+func extractMsg(logs []any) (string, []any) {
+	if len(logs) < 2 {
+		return "", logs
+	}
+	for i := 0; i < len(logs); i += 2 {
+		if field, ok := logs[i].(string); ok && field == "msg" {
+			if i+1 < len(logs) {
+				if field, ok = logs[i+1].(string); ok {
+					return field, append(logs[0:i], logs[i+2:]...)
+				}
+			}
+		}
+	}
+	return "", logs
+}
+
+// Info logs to the slog at the info level.
+func (logger *Logger) Info(logs ...interface{}) {
+	allLogs := append(logger.lctx, logs...)
+	msg, msglessLogs := extractMsg(allLogs)
+	logger.slogger.Info(msg, msglessLogs...)
+}
+
+// Debug logs to the slog with at the debug level.
+func (logger *Logger) Debug(logs ...interface{}) {
+	allLogs := append(logger.lctx, logs...)
+	msg, msglessLogs := extractMsg(allLogs)
+	logger.slogger.Debug(msg, msglessLogs...)
+}
+
+// With returns a logger with additoinal context.
+func (logger *Logger) With(logs ...interface{}) log.Logger {
+	logger2 := *logger
+	logger2.lctx = append(logger2.lctx, logs...)
+	return &logger2
+}

--- a/log/slog/slog_test.go
+++ b/log/slog/slog_test.go
@@ -1,0 +1,30 @@
+package slog
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestContext(t *testing.T) {
+	logger := &Logger{}
+	logger2 := logger.With("msg1", "hello")
+	logger3 := logger2.With("msg2", "world")
+	logger4 := logger3.(*Logger)
+
+	if have, want := len(logger4.lctx), 4; have != want {
+		t.Errorf("length: have: %v, want: %v", have, want)
+	}
+}
+
+func TestExtractMsg(t *testing.T) {
+	logs := []any{"foo", "bar", "msg", "wow", "hello", "world"}
+	msg, msglessLogs := extractMsg(logs)
+
+	if have, want := msg, "wow"; have != want {
+		t.Errorf("msg: have: %v, want: %v", have, want)
+	}
+
+	if have, want := msglessLogs, []any{"foo", "bar", "hello", "world"}; !reflect.DeepEqual(have, want) {
+		t.Errorf("msg: have: %v, want: %v", have, want)
+	}
+}


### PR DESCRIPTION
Now that NanoDEP uses a more recent Go version we get to use even more stdlib features. One of those is [Go's new structured logging](https://go.dev/blog/slog). This PR adds in an adapter from Nano-suite (i.e. NanoLIB, taken from [go-log](https://github.com/jessepeterson/go-log)) logging to [slog](https://pkg.go.dev/log/slog) logging. We also split out the "caller" behavior to keep that similar functionality, too.

Logging now looks like:

```
time=2025-10-16T14:01:25.390-07:00 level=INFO msg="starting server" listen=:9001 caller=main.go:126
```