### PR TITLE
Add collapased section about Nanomdm configuration

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -89,17 +89,31 @@ $ ./tools/dep-account-detail.sh
 
 If you received no response here then you can e.g. set `export CURL_OPTS=-v` to give us more detail and check the `depserver` logs if necessary. See the [operations guide](../docs/operations-guide.md) for more.
 
-Otherwise: congratulations! The token exchanged was successful and you can use the tokens to communicate with Apple's DEP API. **Note: you will need renew these tokens yearly or whenever the Apple Terms and Conditions are updated by following this same procedure.**
+Otherwise: congratulations! The token exchanged was successful and you can use the tokens to communicate with Apple's DEP API. **Note: you will need to renew these tokens yearly or whenever the Apple Terms and Conditions are updated by following this same procedure.**
 
 ### Assign a device in the portal
 
-Now that we've verified API connectivity using your DEP server you need to assign a device in the ABM/ASM/BE portal. To do so login to the portal and navigate to the "Devices" section. Select (or search for) the device you want to use with DEP by settings its MDM server. As of July, 2022 there is a link/button in the top navigation of a device called "Edit MDM Server" — clicking this brings up a dialog to either assign or un-assign the device. When assigning a drop-menu appears of the setup MDM servers. We'll want to select our newly created server "mdmserver1" then click the "Continue" button. The device should then be assigned to your MDM server and available for a DEP profile to be assigned to it.
+Now that we've verified API connectivity using your DEP server you need to assign a device in the ABM/ASM/BE portal. To do so login to the portal and navigate to the "Devices" section. Select (or search for) the device you want to use with DEP by setting its MDM server. As of July, 2022 there is a link/button in the top navigation of a device called "Edit MDM Server" — clicking this brings up a dialog to either assign or un-assign the device. When assigning a drop-menu appears of the setup MDM servers. We'll want to select our newly created server "mdmserver1" then click the "Continue" button. The device should then be assigned to your MDM server and available for a DEP profile to be assigned to it.
 
 ### Define a DEP Profile and assign a device
 
 DEP works by associating devices (serial numbers) with DEP profiles. A DEP profile is a set of properties associated to a UUID and, importantly, specifies the URL location of our MDM server our device enrolls into. We can define a DEP profile with its properties *and* associate serial numbers in one step.
 
 First adjust the [example DEP profile](../docs/dep-profile.example.json) or make a copy of it. Critically you'll need to point the profile at your MDM using the `url` or `configuration_web_url` properties. See the [Apple docs](https://developer.apple.com/documentation/devicemanagement/profile) for the various configuration options. For the below example I adjust a few parameters, made sure my MDM URL is correct, and added the serial `07AAD449616F566C12` to the `devices` array in the profile (note only serial number adjustment shown here, you *will* need to adjust other parameters of the profile):
+
+<details>
+  <summary>Note for nanoMDM users</summary>
+  
+  NanoMDM does not have an enrollment endpoint interface for the `url` field in the dep-profile. You will need to host your `enroll.mobileconfig` file yourself. In addition, the request is made as a POST. One simple option is creating a custom location section in Nginx and using it's built in error page redirect feature.
+  ```nginx config snippet
+    location /enrollment-url {
+         alias /var/www/html/optional_subdir/enroll.mobileconfig;
+         error_page 405 =200 $uri;
+         default_type application/x-apple-aspen-conf;
+    }
+  ```
+  Now simply replace `https://mymdm.example.org/mdm/enroll` with `https://mymdm.example.org/enrollment-url` in your dep profile.
+</details>
 
 ```diff
 --- a/docs/dep-profile.example.json
@@ -125,7 +139,7 @@ $ ./tools/dep-define-profile.sh ./docs/dep-profile.example.json
 }
 ```
 
-Here the API has responded telling us the profile UUID `43277A13FBCA0CFC` has been defined and that it had success in assigning the serial number `07AAD449616F566C12` this DEP profile.
+Here the API has responded telling us the profile UUID `43277A13FBCA0CFC` has been defined and that it had success in assigning the serial number `07AAD449616F566C12` to this DEP profile.
 
 ### Verify device ADE
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -101,19 +101,12 @@ DEP works by associating devices (serial numbers) with DEP profiles. A DEP profi
 
 First adjust the [example DEP profile](../docs/dep-profile.example.json) or make a copy of it. Critically you'll need to point the profile at your MDM using the `url` or `configuration_web_url` properties. See the [Apple docs](https://developer.apple.com/documentation/devicemanagement/profile) for the various configuration options. For the below example I adjust a few parameters, made sure my MDM URL is correct, and added the serial `07AAD449616F566C12` to the `devices` array in the profile (note only serial number adjustment shown here, you *will* need to adjust other parameters of the profile):
 
-<details>
-  <summary>Note for nanoMDM users</summary>
-  
-  NanoMDM does not have an enrollment endpoint interface for the `url` field in the dep-profile. You will need to host your `enroll.mobileconfig` file on a webserver yourself. In addition, the request is made as a POST. For example, in Nginx you can create a custom location section and use it's built in error page redirect feature to achieve this.
-  ```nginx config snippet
-    location /enrollment-url {
-         alias /var/www/html/optional_subdir/enroll.mobileconfig;
-         error_page 405 =200 $uri;
-         default_type application/x-apple-aspen-conf;
-    }
-  ```
-  Now simply replace `https://mymdm.example.org/mdm/enroll` with `https://mymdm.example.org/enrollment-url` in your dep profile.
-</details>
+#### Note on serving the enrollment profile
+
+> [!TIP]
+> The MDM profile served from the `url` field (or the newer `configuration_web_url`) must be served from a web server setup by you. NanoDEP does not have a facility to host it, nor do some open source MDM servers (such as NanoMDM).
+
+Note the `dep` URL requires a `POST` HTTP request, and the `configuration_web_url` uses `GET`. These URLs must serve a normal Apple MDM Enrollment Configuration Profile (XML plist). The profile should be served with a MIME type of `application/x-apple-aspen-config`. See Apple's docs regarding [Authenticating through web views](https://developer.apple.com/documentation/devicemanagement/authenticating-through-web-views) for more details.
 
 ```diff
 --- a/docs/dep-profile.example.json

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -104,7 +104,7 @@ First adjust the [example DEP profile](../docs/dep-profile.example.json) or make
 <details>
   <summary>Note for nanoMDM users</summary>
   
-  NanoMDM does not have an enrollment endpoint interface for the `url` field in the dep-profile. You will need to host your `enroll.mobileconfig` file yourself. In addition, the request is made as a POST. One simple option is creating a custom location section in Nginx and using it's built in error page redirect feature.
+  NanoMDM does not have an enrollment endpoint interface for the `url` field in the dep-profile. You will need to host your `enroll.mobileconfig` file on a webserver yourself. In addition, the request is made as a POST. For example, in Nginx you can create a custom location section and use it's built in error page redirect feature to achieve this.
   ```nginx config snippet
     location /enrollment-url {
          alias /var/www/html/optional_subdir/enroll.mobileconfig;


### PR DESCRIPTION
The example dep profile makes it appear like NanoMDM would support serving of enroll.mobileconfig files from it's /mdm endpoint. I provide a small section here to prevent future end user frustration.