### PR TITLE
Add support for Migrating managed devices

### DIFF
--- a/client/transport.go
+++ b/client/transport.go
@@ -16,7 +16,7 @@ const (
 	ADMAuthSession        = "X-ADM-Auth-Session"
 	ServerProtocolVersion = "X-Server-Protocol-Version"
 
-	DefaultServerProtocolVersion = "7"
+	DefaultServerProtocolVersion = "8"
 
 	SessionEndpoint = "/session"
 

--- a/cmd/depsyncer/main.go
+++ b/cmd/depsyncer/main.go
@@ -31,6 +31,7 @@ func main() {
 		flDebug   = flag.Bool("debug", false, "log debug messages")
 		flADebug  = flag.Bool("debug-assigner", false, "additional debug logging of the device assigner")
 		flSDebug  = flag.Bool("debug-syncer", false, "additional debug logging of the device syncer")
+		flDeadln  = flag.Bool("deadline", false, "assign profiles to devices undergoing ADE deadline migration")
 		flStorage = flag.String("storage", "filekv", "storage backend")
 		flDSN     = flag.String("storage-dsn", "", "storage backend data source name")
 		flOptions = flag.String("storage-options", "", "storage backend options")
@@ -138,6 +139,9 @@ func main() {
 		}
 		if *flADebug {
 			assignerOpts = append(assignerOpts, depsync.WithAssignerDebug())
+		}
+		if *flDeadln {
+			assignerOpts = append(assignerOpts, depsync.WithAssignerDeadline())
 		}
 		assigner := depsync.NewAssigner(
 			client,

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -487,7 +487,6 @@ And then run the script again. This should give detailed HTTP response data incl
 
 You can set the assigner profile UUID using either the `./tools/cfg-set-assigner.sh` script (which talks to `depserver`) or using the `depserver` API endpoint `/v1/assigner/{name}` directly. See above for documentation on either of these options. The assigner can be set or changed at any time — even if `depsyncer` has already started: it reads the profile UUID every sync cycle. Note also that the assigner profile UUID applies only to the specific associated DEP name.
 
-
 ### Usage
 
 At minimum you must specify at least one DEP name to start syncing devices from:

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -487,6 +487,8 @@ And then run the script again. This should give detailed HTTP response data incl
 
 You can set the assigner profile UUID using either the `./tools/cfg-set-assigner.sh` script (which talks to `depserver`) or using the `depserver` API endpoint `/v1/assigner/{name}` directly. See above for documentation on either of these options. The assigner can be set or changed at any time — even if `depsyncer` has already started: it reads the profile UUID every sync cycle. Note also that the assigner profile UUID applies only to the specific associated DEP name.
 
+By default the assigner only considers newly *added* devices (those with an op_type of "added"). If you enable the `-deadline` flag then devices undergoing ADE (Automated Device Enrollment) deadline migration are also assigned. Such devices are reported with an op_type of "modified" and a profile_status of "removed" rather than the usual "added" op_type. See the `-deadline` flag documentation below.
+
 ### Usage
 
 At minimum you must specify at least one DEP name to start syncing devices from:
@@ -519,6 +521,12 @@ You should then see in the running `depsyncer` process:
 Whereby the next sync should be immediately started. Naturally signal handling is OS dependent and so this feature will not work on Microsoft Windows. `depsyncer` also tries to handle the Interrupt and Terminate (SIGTERM) signals to try to cleanly stop the syncer(s) and shutdown the process.
 
 ### Command line flags
+
+#### -deadline
+
+* assign profiles to devices undergoing ADE deadline migration
+
+By default the assigner only assigns the profile UUID to newly *added* devices. When this flag is enabled the assigner will also assign the profile UUID to devices undergoing ADE (Automated Device Enrollment) deadline migration. These devices are reported by the Apple DEP API with an op_type of "modified" and a profile_status of "removed" instead of the usual "added" op_type. This flag applies in both "continuous" and "sync once" modes.
 
 #### -debug
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -487,7 +487,6 @@ And then run the script again. This should give detailed HTTP response data incl
 
 You can set the assigner profile UUID using either the `./tools/cfg-set-assigner.sh` script (which talks to `depserver`) or using the `depserver` API endpoint `/v1/assigner/{name}` directly. See above for documentation on either of these options. The assigner can be set or changed at any time — even if `depsyncer` has already started: it reads the profile UUID every sync cycle. Note also that the assigner profile UUID applies only to the specific associated DEP name.
 
-By default the assigner only considers newly *added* devices (those with an op_type of "added"). If you enable the `-deadline` flag then devices undergoing ADE (Automated Device Enrollment) deadline migration are also assigned. Such devices are reported with an op_type of "modified" and a profile_status of "removed" rather than the usual "added" op_type. See the `-deadline` flag documentation below.
 
 ### Usage
 

--- a/sync/assigner.go
+++ b/sync/assigner.go
@@ -90,11 +90,25 @@ func (a *Assigner) ProcessDeviceResponse(ctx context.Context, resp *godep.FetchD
 		if a.debug {
 			logs := []interface{}{"msg", "device"}
 			logs = append(logs, logDevice(device)...)
+			if device.MdmMigrationDeadline != nil {
+				logs = append(logs,
+					"mdm_migration", true,
+					"migration_deadline", device.MdmMigrationDeadline.String(),
+				)
+			}
+
 			logger.Debug(logs...)
 		}
 		// note that we may see multiple serial number "events"
 		if shouldAssignDevice(device) {
 			serialsToAssign = append(serialsToAssign, device.SerialNumber)
+		}
+		if device.MdmMigrationDeadline != nil {
+			logger.Info(
+				"msg", "migration device detected",
+				"serial_number", device.SerialNumber,
+				"migration_deadline", device.MdmMigrationDeadline.String(),
+			)
 		}
 	}
 

--- a/sync/assigner.go
+++ b/sync/assigner.go
@@ -96,7 +96,6 @@ func (a *Assigner) ProcessDeviceResponse(ctx context.Context, resp *godep.FetchD
 					"migration_deadline", device.MdmMigrationDeadline.String(),
 				)
 			}
-
 			logger.Debug(logs...)
 		}
 		// note that we may see multiple serial number "events"

--- a/sync/assigner.go
+++ b/sync/assigner.go
@@ -92,7 +92,8 @@ func (a *Assigner) ProcessDeviceResponse(ctx context.Context, resp *godep.FetchD
 			logs = append(logs, logDevice(device)...)
 			if device.MdmMigrationDeadline != nil {
 				logs = append(logs,
-					"mdm_migration", true,
+					"msg", "migration device detected",
+					"serial_number", device.SerialNumber,
 					"migration_deadline", device.MdmMigrationDeadline.String(),
 				)
 			}
@@ -101,13 +102,6 @@ func (a *Assigner) ProcessDeviceResponse(ctx context.Context, resp *godep.FetchD
 		// note that we may see multiple serial number "events"
 		if shouldAssignDevice(device) {
 			serialsToAssign = append(serialsToAssign, device.SerialNumber)
-		}
-		if device.MdmMigrationDeadline != nil {
-			logger.Info(
-				"msg", "migration device detected",
-				"serial_number", device.SerialNumber,
-				"migration_deadline", device.MdmMigrationDeadline.String(),
-			)
 		}
 	}
 

--- a/sync/assigner.go
+++ b/sync/assigner.go
@@ -92,7 +92,7 @@ func (a *Assigner) ProcessDeviceResponse(ctx context.Context, resp *godep.FetchD
 			logs = append(logs, logDevice(device)...)
 			if device.MdmMigrationDeadline != nil {
 				logs = append(logs,
-					"msg", "migration device detected",
+                    "mdm_migration", true,
 					"serial_number", device.SerialNumber,
 					"migration_deadline", device.MdmMigrationDeadline.String(),
 				)

--- a/sync/assigner.go
+++ b/sync/assigner.go
@@ -139,6 +139,12 @@ func shouldAssignDevice(device godep.DeviceJson) bool {
 	if strings.ToLower(string(deref(device.OpType))) == "added" {
 		return true
 	}
+	// An exception to this is if a device is using ADE deadline migration.
+	// It's OpType will be "modified" with ProfileStatus being "removed".
+	if strings.ToLower(string(deref(device.OpType))) == "modified" &&
+		strings.ToLower(string(deref(device.ProfileStatus))) == "removed" {
+		return true
+	}
 	return false
 }
 

--- a/sync/assigner.go
+++ b/sync/assigner.go
@@ -90,12 +90,6 @@ func (a *Assigner) ProcessDeviceResponse(ctx context.Context, resp *godep.FetchD
 		if a.debug {
 			logs := []interface{}{"msg", "device"}
 			logs = append(logs, logDevice(device)...)
-			if device.MdmMigrationDeadline != nil {
-				logs = append(logs,
-                    "mdm_migration", true,
-					"serial_number", device.SerialNumber,
-					"migration_deadline", device.MdmMigrationDeadline.String(),
-				)
 			}
 			logger.Debug(logs...)
 		}

--- a/sync/assigner.go
+++ b/sync/assigner.go
@@ -20,11 +20,12 @@ type AssignerProfileRetriever interface {
 
 // Assigner assigns devices synced from the Apple DEP APIs to a profile UUID.
 type Assigner struct {
-	client *godep.Client
-	name   string
-	store  AssignerProfileRetriever
-	logger log.Logger
-	debug  bool
+	client   *godep.Client
+	name     string
+	store    AssignerProfileRetriever
+	logger   log.Logger
+	debug    bool
+	deadline bool
 }
 
 type AssignerOption func(*Assigner)
@@ -61,6 +62,16 @@ func WithAssignerDebug() AssignerOption {
 	}
 }
 
+// WithAssignerDeadline enables assigning the profile UUID to devices
+// undergoing ADE deadline migration. These devices report an op_type of
+// "modified" with a profile_status of "removed" instead of the usual
+// "added" op_type.
+func WithAssignerDeadline() AssignerOption {
+	return func(a *Assigner) {
+		a.deadline = true
+	}
+}
+
 // ProcessDeviceResponse processes the device response from the device sync
 // DEP API endpoints and assigns the profile UUID associated with the DEP
 // client DEP name.
@@ -93,7 +104,7 @@ func (a *Assigner) ProcessDeviceResponse(ctx context.Context, resp *godep.FetchD
 			logger.Debug(logs...)
 		}
 		// note that we may see multiple serial number "events"
-		if shouldAssignDevice(device) {
+		if shouldAssignDevice(device, a.deadline) {
 			serialsToAssign = append(serialsToAssign, device.SerialNumber)
 		}
 	}
@@ -132,7 +143,7 @@ func (a *Assigner) ProcessDeviceResponse(ctx context.Context, resp *godep.FetchD
 
 // shouldAssignDevice decides whether a device "event" should be passed
 // off to the assigner.
-func shouldAssignDevice(device godep.DeviceJson) bool {
+func shouldAssignDevice(device godep.DeviceJson, deadline bool) bool {
 	// we currently only listen for an op_type of "added." the other
 	// op_types are ambiguous and it would be needless to assign the
 	// profile UUID every single time we get an update.
@@ -141,7 +152,8 @@ func shouldAssignDevice(device godep.DeviceJson) bool {
 	}
 	// An exception to this is if a device is using ADE deadline migration.
 	// It's OpType will be "modified" with ProfileStatus being "removed".
-	if strings.ToLower(string(deref(device.OpType))) == "modified" &&
+	if deadline &&
+		strings.ToLower(string(deref(device.OpType))) == "modified" &&
 		strings.ToLower(string(deref(device.ProfileStatus))) == "removed" {
 		return true
 	}

--- a/sync/assigner.go
+++ b/sync/assigner.go
@@ -90,7 +90,6 @@ func (a *Assigner) ProcessDeviceResponse(ctx context.Context, resp *godep.FetchD
 		if a.debug {
 			logs := []interface{}{"msg", "device"}
 			logs = append(logs, logDevice(device)...)
-			}
 			logger.Debug(logs...)
 		}
 		// note that we may see multiple serial number "events"

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -296,5 +296,11 @@ func logDevice(device godep.DeviceJson) []interface{} {
 	if device.ProfilePushTime != nil && !device.ProfilePushTime.IsZero() {
 		logs = append(logs, "push_push_time", *device.ProfilePushTime)
 	}
+	if device.MdmMigrationDeadline != nil {
+		logs = append(logs,
+			"mdm_migration", true,
+			"migration_deadline", device.MdmMigrationDeadline.String(),
+		)
+	}
 	return logs
 }


### PR DESCRIPTION
This enables [mdm_migration_deadline](https://developer.apple.com/documentation/devicemanagement/migrating-managed-devices#:~:text=to%20a%20migration.-,Important,-The%20device%20management) support. Also added some logging to aid in migration troubleshooting.