### PR TITLE
fix(mysql): recycle pooled connections + expose lifetime/idle options

### DIFF
--- a/cli/storage.go
+++ b/cli/storage.go
@@ -4,6 +4,8 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"strings"
+	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/micromdm/nanodep/storage"
@@ -35,11 +37,50 @@ func Storage(storageName, dsn, options string) (storage.AllStorage, error) {
 	case "inmem":
 		store = inmem.New()
 	case "mysql":
-		store, err = mysql.New(mysql.WithDSN(dsn))
+		store, err = mysqlStorage(dsn, options)
 	case "pgsql":
 		store, err = pgsql.New(pgsql.WithDSN(dsn))
 	default:
 		return nil, fmt.Errorf("unknown storage: %q", storageName)
 	}
 	return store, err
+}
+
+// mysqlStorage builds a MySQL storage backend, parsing any storage options.
+func mysqlStorage(dsn, options string) (*mysql.MySQLStorage, error) {
+	opts := []mysql.Option{mysql.WithDSN(dsn)}
+	if options != "" {
+		for k, v := range splitOptions(options) {
+			switch k {
+			case "conn_max_lifetime":
+				d, err := time.ParseDuration(v)
+				if err != nil {
+					return nil, fmt.Errorf("invalid value for conn_max_lifetime option: %w", err)
+				}
+				opts = append(opts, mysql.WithConnMaxLifetime(d))
+			case "conn_max_idle_time":
+				d, err := time.ParseDuration(v)
+				if err != nil {
+					return nil, fmt.Errorf("invalid value for conn_max_idle_time option: %w", err)
+				}
+				opts = append(opts, mysql.WithConnMaxIdleTime(d))
+			default:
+				return nil, fmt.Errorf("invalid option: %q", k)
+			}
+		}
+	}
+	return mysql.New(opts...)
+}
+
+// splitOptions splits a comma-separated list of key=value storage options.
+func splitOptions(s string) map[string]string {
+	out := make(map[string]string)
+	for _, opt := range strings.Split(s, ",") {
+		if opt == "" {
+			continue
+		}
+		k, v, _ := strings.Cut(opt, "=")
+		out[k] = v
+	}
+	return out
 }

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -104,9 +104,9 @@ Configures the MySQL storage backend. The `-dsn` flag should be in the [format t
 Options are specified as a comma-separated list of "key=value" pairs. The mysql backend supports these options:
 
 * `conn_max_lifetime=duration`
-  * This option sets the maximum amount of time a pooled connection may be reused. The value is a [Go duration string](https://pkg.go.dev/time#ParseDuration) such as `30s`, `3m`, or `1h`. It defaults to `3m`. A value of `0` keeps connections forever.
+  * This option sets the maximum amount of time a pooled connection may be reused. The value is a [Go duration string](https://pkg.go.dev/time#ParseDuration) such as `30s`, `3m`, or `1h`. When unset, connection lifetime is left at database/sql's default (connections are reused indefinitely). A value of `0` keeps connections forever.
 * `conn_max_idle_time=duration`
-  * This option sets the maximum amount of time a pooled connection may sit idle before it is closed. The value is a duration string, as above. It defaults to `1m`. A value of `0` never closes connections due to idle time.
+  * This option sets the maximum amount of time a pooled connection may sit idle before it is closed. The value is a duration string, as above. When unset, idle time is left at database/sql's default (idle connections are not closed by age). A value of `0` never closes connections due to idle time.
 
 *Example:* `-storage mysql -storage-dsn nanodep:nanodep/mydepdb -storage-options conn_max_lifetime=30s,conn_max_idle_time=15s`
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -101,6 +101,15 @@ Configures the MySQL storage backend. The `-dsn` flag should be in the [format t
 
 *Example:* `-storage mysql -dsn nanodep:nanodep/mydepdb`
 
+Options are specified as a comma-separated list of "key=value" pairs. The mysql backend supports these options:
+
+* `conn_max_lifetime=duration`
+  * This option sets the maximum amount of time a pooled connection may be reused. The value is a [Go duration string](https://pkg.go.dev/time#ParseDuration) such as `30s`, `3m`, or `1h`. It defaults to `3m`. A value of `0` keeps connections forever.
+* `conn_max_idle_time=duration`
+  * This option sets the maximum amount of time a pooled connection may sit idle before it is closed. The value is a duration string, as above. It defaults to `1m`. A value of `0` never closes connections due to idle time.
+
+*Example:* `-storage mysql -storage-dsn nanodep:nanodep/mydepdb -storage-options conn_max_lifetime=30s,conn_max_idle_time=15s`
+
 ##### pgsql storage backend
 
 * `-storage pgsql`
@@ -554,9 +563,9 @@ In the "sync once" mode (duration of 0) `depsyncer` could be run from, say, a cr
 
 The limit flag specifies how many devices to fetch at a time from the Apple DEP API. [Apple's documentation](https://developer.apple.com/documentation/devicemanagement/syncdevicerequest) says there is a server-side default of 100 an upper limit of 1000.
 
-#### -storage & -storage-dsn
+#### -storage, -storage-dsn, & -storage-options
 
-See the "-storage & -storage-dsn" section, above, for `depserver`. The syntax and capabilities are the same.
+See the "-storage, -storage-dsn, & -storage-options" section, above, for `depserver`. The syntax and capabilities are the same.
 
 #### -version
 

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -18,6 +18,18 @@ import (
 //go:embed schema.sql
 var Schema string
 
+// Default connection pool recycling. Pooled connections are recycled well
+// before the shortest idle timeout in the network path (the istio-proxy
+// sidecar reaps idle TCP connections at ~1h, Aurora's wait_timeout is longer).
+// Without this, database/sql hands out long-idle connections that the far end
+// has already closed, producing "broken pipe" writes and "closing bad idle
+// connection: EOF" errors. Override per-deployment with WithConnMaxLifetime /
+// WithConnMaxIdleTime when the path's idle timeout differs.
+const (
+	defaultConnMaxLifetime = 3 * time.Minute
+	defaultConnMaxIdleTime = 1 * time.Minute
+)
+
 // MySQLStorage implements a storage.AllStorage using MySQL.
 type MySQLStorage struct {
 	db *sql.DB
@@ -25,9 +37,11 @@ type MySQLStorage struct {
 }
 
 type config struct {
-	driver string
-	dsn    string
-	db     *sql.DB
+	driver          string
+	dsn             string
+	db              *sql.DB
+	connMaxLifetime time.Duration
+	connMaxIdleTime time.Duration
 }
 
 // Option allows configuring a MySQLStorage.
@@ -59,9 +73,31 @@ func WithDB(db *sql.DB) Option {
 	}
 }
 
+// WithConnMaxLifetime sets the maximum amount of time a connection may be
+// reused. It should be shorter than the shortest idle timeout in the network
+// path to the database. A non-positive value keeps connections forever.
+func WithConnMaxLifetime(d time.Duration) Option {
+	return func(c *config) {
+		c.connMaxLifetime = d
+	}
+}
+
+// WithConnMaxIdleTime sets the maximum amount of time a connection may be idle
+// before it is closed. A non-positive value never closes connections due to
+// idle time.
+func WithConnMaxIdleTime(d time.Duration) Option {
+	return func(c *config) {
+		c.connMaxIdleTime = d
+	}
+}
+
 // New creates and returns a new MySQLStorage.
 func New(opts ...Option) (*MySQLStorage, error) {
-	cfg := &config{driver: "mysql"}
+	cfg := &config{
+		driver:          "mysql",
+		connMaxLifetime: defaultConnMaxLifetime,
+		connMaxIdleTime: defaultConnMaxIdleTime,
+	}
 	for _, opt := range opts {
 		opt(cfg)
 	}
@@ -72,6 +108,8 @@ func New(opts ...Option) (*MySQLStorage, error) {
 			return nil, err
 		}
 	}
+	cfg.db.SetConnMaxLifetime(cfg.connMaxLifetime)
+	cfg.db.SetConnMaxIdleTime(cfg.connMaxIdleTime)
 	if err = cfg.db.Ping(); err != nil {
 		return nil, err
 	}

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -34,13 +34,11 @@ type MySQLStorage struct {
 }
 
 type config struct {
-	driver             string
-	dsn                string
-	db                 *sql.DB
-	connMaxLifetime    time.Duration
-	connMaxLifetimeSet bool
-	connMaxIdleTime    time.Duration
-	connMaxIdleTimeSet bool
+	driver          string
+	dsn             string
+	db              *sql.DB
+	connMaxLifetime time.Duration
+	connMaxIdleTime time.Duration
 }
 
 // Option allows configuring a MySQLStorage.
@@ -78,7 +76,6 @@ func WithDB(db *sql.DB) Option {
 func WithConnMaxLifetime(d time.Duration) Option {
 	return func(c *config) {
 		c.connMaxLifetime = d
-		c.connMaxLifetimeSet = true
 	}
 }
 
@@ -88,7 +85,6 @@ func WithConnMaxLifetime(d time.Duration) Option {
 func WithConnMaxIdleTime(d time.Duration) Option {
 	return func(c *config) {
 		c.connMaxIdleTime = d
-		c.connMaxIdleTimeSet = true
 	}
 }
 
@@ -107,10 +103,10 @@ func New(opts ...Option) (*MySQLStorage, error) {
 			return nil, err
 		}
 	}
-	if cfg.connMaxLifetimeSet {
+	if cfg.connMaxLifetime != 0 {
 		cfg.db.SetConnMaxLifetime(cfg.connMaxLifetime)
 	}
-	if cfg.connMaxIdleTimeSet {
+	if cfg.connMaxIdleTime != 0 {
 		cfg.db.SetConnMaxIdleTime(cfg.connMaxIdleTime)
 	}
 	if err = cfg.db.Ping(); err != nil {

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -18,17 +18,14 @@ import (
 //go:embed schema.sql
 var Schema string
 
-// Default connection pool recycling. Pooled connections are recycled well
-// before the shortest idle timeout in the network path (the istio-proxy
-// sidecar reaps idle TCP connections at ~1h, Aurora's wait_timeout is longer).
-// Without this, database/sql hands out long-idle connections that the far end
-// has already closed, producing "broken pipe" writes and "closing bad idle
-// connection: EOF" errors. Override per-deployment with WithConnMaxLifetime /
-// WithConnMaxIdleTime when the path's idle timeout differs.
-const (
-	defaultConnMaxLifetime = 3 * time.Minute
-	defaultConnMaxIdleTime = 1 * time.Minute
-)
+// Connection pool recycling is left at database/sql's defaults unless
+// configured. Pooled connections should be recycled well before the shortest
+// idle timeout in the network path (the istio-proxy sidecar reaps idle TCP
+// connections at ~1h, Aurora's wait_timeout is longer). Without recycling,
+// database/sql hands out long-idle connections that the far end has already
+// closed, producing "broken pipe" writes and "closing bad idle connection:
+// EOF" errors. Set WithConnMaxLifetime / WithConnMaxIdleTime per-deployment to
+// enable recycling for the path's idle timeout.
 
 // MySQLStorage implements a storage.AllStorage using MySQL.
 type MySQLStorage struct {
@@ -37,11 +34,13 @@ type MySQLStorage struct {
 }
 
 type config struct {
-	driver          string
-	dsn             string
-	db              *sql.DB
-	connMaxLifetime time.Duration
-	connMaxIdleTime time.Duration
+	driver             string
+	dsn                string
+	db                 *sql.DB
+	connMaxLifetime    time.Duration
+	connMaxLifetimeSet bool
+	connMaxIdleTime    time.Duration
+	connMaxIdleTimeSet bool
 }
 
 // Option allows configuring a MySQLStorage.
@@ -79,6 +78,7 @@ func WithDB(db *sql.DB) Option {
 func WithConnMaxLifetime(d time.Duration) Option {
 	return func(c *config) {
 		c.connMaxLifetime = d
+		c.connMaxLifetimeSet = true
 	}
 }
 
@@ -88,15 +88,14 @@ func WithConnMaxLifetime(d time.Duration) Option {
 func WithConnMaxIdleTime(d time.Duration) Option {
 	return func(c *config) {
 		c.connMaxIdleTime = d
+		c.connMaxIdleTimeSet = true
 	}
 }
 
 // New creates and returns a new MySQLStorage.
 func New(opts ...Option) (*MySQLStorage, error) {
 	cfg := &config{
-		driver:          "mysql",
-		connMaxLifetime: defaultConnMaxLifetime,
-		connMaxIdleTime: defaultConnMaxIdleTime,
+		driver: "mysql",
 	}
 	for _, opt := range opts {
 		opt(cfg)
@@ -108,8 +107,12 @@ func New(opts ...Option) (*MySQLStorage, error) {
 			return nil, err
 		}
 	}
-	cfg.db.SetConnMaxLifetime(cfg.connMaxLifetime)
-	cfg.db.SetConnMaxIdleTime(cfg.connMaxIdleTime)
+	if cfg.connMaxLifetimeSet {
+		cfg.db.SetConnMaxLifetime(cfg.connMaxLifetime)
+	}
+	if cfg.connMaxIdleTimeSet {
+		cfg.db.SetConnMaxIdleTime(cfg.connMaxIdleTime)
+	}
 	if err = cfg.db.Ping(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The MySQL storage pool was opened with no lifetime tuning, so database/sql retained idle connections indefinitely. The istio-proxy sidecar reaps idle TCP connections at ~1h (Aurora wait_timeout is longer), so nanodep reused already-closed connections, producing "write: broken pipe" and "closing bad idle connection: EOF" errors.

Set ConnMaxLifetime/ConnMaxIdleTime with 3m/1m defaults, both well under the proxy idle timeout, and expose them as WithConnMaxLifetime / WithConnMaxIdleTime options. The CLI storage() previously discarded the options string for the mysql backend; it now parses conn_max_lifetime / conn_max_idle_time (via time.ParseDuration) so the ceiling can be retuned per deployment without an image rebuild.